### PR TITLE
Update default precision

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,13 @@ Usage
     import numpy as np
     from quadax import quadgk
 
-    f = lambda t: t * jnp.log(1 + t)
+    fun = lambda t: t * jnp.log(1 + t)
 
-    epsabs = epsrel = 1e-14
+    epsabs = epsrel = 1e-5 # by default jax uses 32 bit, higher accuracy requires going to 64 bit
     a, b = 0, 1
     y, info = quadgk(fun, [a, b], epsabs=epsabs, epsrel=epsrel)
     assert info.err < max(epsabs, epsrel*abs(y))
-    np.testing.assert_allclose(y, 1/4, rtol=1e-14, atol=1e-14)
+    np.testing.assert_allclose(y, 1/4, rtol=epsrel, atol=epsabs)
 
 
 For full details of various options see the `API documentation <https://quadax.readthedocs.io/en/latest/api.html>`__

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -4,7 +4,14 @@ import jax
 import jax.numpy as jnp
 
 from .fixed_order import fixed_quadcc, fixed_quadgk, fixed_quadts
-from .utils import QuadratureInfo, bounded_while_loop, errorif, map_interval, wrap_func
+from .utils import (
+    QuadratureInfo,
+    bounded_while_loop,
+    errorif,
+    map_interval,
+    setdefault,
+    wrap_func,
+)
 
 NORMAL_EXIT = 0
 MAX_NINTER = 1
@@ -19,8 +26,8 @@ def quadgk(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     max_ninter=50,
     order=21,
     norm=jnp.inf,
@@ -49,10 +56,10 @@ def quadgk(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is 1.4e-8. Algorithm tries to
-        obtain an accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))``
-        where ``i`` = integral of `fun` over `interval`, and ``result`` is the
-        numerical approximation.
+        Absolute and relative error tolerance. Default is square root of
+        machine precision. Algorithm tries to obtain an accuracy of
+        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
+        `fun` over `interval`, and ``result`` is the numerical approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -120,8 +127,8 @@ def quadcc(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     max_ninter=50,
     order=32,
     norm=jnp.inf,
@@ -149,10 +156,10 @@ def quadcc(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is 1.4e-8. Algorithm tries to
-        obtain an accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))``
-        where ``i`` = integral of `fun` over `interval`, and ``result`` is the
-        numerical approximation.
+        Absolute and relative error tolerance. Default is square root of
+        machine precision. Algorithm tries to obtain an accuracy of
+        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
+        `fun` over `interval`, and ``result`` is the numerical approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -220,8 +227,8 @@ def quadts(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     max_ninter=50,
     order=61,
     norm=jnp.inf,
@@ -248,10 +255,10 @@ def quadts(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is 1.4e-8. Algorithm tries to
-        obtain an accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))``
-        where ``i`` = integral of `fun` over `interval`, and ``result`` is the
-        numerical approximation.
+        Absolute and relative error tolerance. Default is square root of
+        machine precision. Algorithm tries to obtain an accuracy of
+        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
+        `fun` over `interval`, and ``result`` is the numerical approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -320,8 +327,8 @@ def adaptive_quadrature(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     max_ninter=50,
     norm=jnp.inf,
     **kwargs,
@@ -356,10 +363,10 @@ def adaptive_quadrature(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is 1.4e-8. Algorithm tries to
-        obtain an accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))``
-        where ``i`` = integral of `fun` over `interval`, and ``result`` is the
-        numerical approximation.
+        Absolute and relative error tolerance. Default is square root of
+        machine precision. Algorithm tries to obtain an accuracy of
+        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
+        `fun` over `interval`, and ``result`` is the numerical approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -404,6 +411,8 @@ def adaptive_quadrature(
         ValueError,
         f"max_ninter={max_ninter} is not enough for {len(interval)-1} breakpoints",
     )
+    epsabs = setdefault(epsabs, jnp.sqrt(jnp.finfo(jnp.array(1.0)).eps))
+    epsrel = setdefault(epsrel, jnp.sqrt(jnp.finfo(jnp.array(1.0)).eps))
     _norm = norm if callable(norm) else lambda x: jnp.linalg.norm(x.flatten(), ord=norm)
     fun, interval = map_interval(fun, interval)
     vfunc = wrap_func(fun, args)

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -8,6 +8,7 @@ from .utils import (
     bounded_while_loop,
     errorif,
     map_interval,
+    setdefault,
     tanhsinh_transform,
     wrap_func,
 )
@@ -18,8 +19,8 @@ def romberg(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     divmax=20,
     norm=jnp.inf,
 ):
@@ -46,7 +47,8 @@ def romberg(
     epsabs, epsrel : float
         Absolute and relative tolerances. If I1 and I2 are two
         successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|)
+        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is square root of
+        machine precision.
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at
@@ -88,6 +90,8 @@ def romberg(
         NotImplementedError,
         "Romberg integration with breakpoints not supported",
     )
+    epsabs = setdefault(epsabs, jnp.sqrt(jnp.finfo(jnp.array(1.0)).eps))
+    epsrel = setdefault(epsrel, jnp.sqrt(jnp.finfo(jnp.array(1.0)).eps))
     _norm = norm if callable(norm) else lambda x: jnp.linalg.norm(x.flatten(), ord=norm)
     # map a, b -> [-1, 1]
     fun, interval = map_interval(fun, interval)
@@ -149,8 +153,8 @@ def rombergts(
     interval,
     args=(),
     full_output=False,
-    epsabs=1.4e-8,
-    epsrel=1.4e-8,
+    epsabs=None,
+    epsrel=None,
     divmax=20,
     norm=jnp.inf,
 ):
@@ -177,7 +181,8 @@ def rombergts(
     epsabs, epsrel : float
         Absolute and relative tolerances. If I1 and I2 are two
         successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|)
+        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is square root of
+        machine precision.
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -268,3 +268,12 @@ def bounded_while_loop(condfun, bodyfun, init_val, bound):
         return jax.lax.cond(condfun(state), bodyfun, lambda x: x, state), None
 
     return jax.lax.scan(scanfun, init_val, None, bound)[0]
+
+
+def setdefault(val, default, cond=None):
+    """Return val if condition is met, otherwise default.
+
+    If cond is None, then it checks if val is not None, returning val
+    or default accordingly.
+    """
+    return val if cond or (cond is None and val is not None) else default


### PR DESCRIPTION
The previous default of 1.4e-8 worked well for 64 bit, but JAX is usually 32 bit by default. The new default tolerance is sqrt of machine precision which should work well for both 32/64

Resolves #2