### PR TITLE
Fix for leaked tracers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install --upgrade -r requirements-dev.txt
+          pip list
       - name: Test with pytest
         run: |
           pwd

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install --upgrade -r requirements-dev.txt
+          pip list
       - name: Test with pytest
         run: |
           pwd

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -2,6 +2,7 @@
 
 import warnings
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 
@@ -28,6 +29,7 @@ NO_CONVERGE = 4
 DIVERGENT = 5
 
 
+@eqx.filter_jit
 def quadgk(
     fun,
     interval,
@@ -128,6 +130,7 @@ def quadgk(
     return y, info
 
 
+@eqx.filter_jit
 def quadcc(
     fun,
     interval,
@@ -227,6 +230,7 @@ def quadcc(
     return y, info
 
 
+@eqx.filter_jit
 def quadts(
     fun,
     interval,
@@ -325,6 +329,7 @@ def quadts(
     return y, info
 
 
+@eqx.filter_jit
 def adaptive_quadrature(
     rule,
     fun,

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -1,5 +1,6 @@
 """Romberg integration aka adaptive trapezoid with Richardson extrapolation."""
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 
@@ -14,6 +15,7 @@ from .utils import (
 )
 
 
+@eqx.filter_jit
 def romberg(
     fun,
     interval,
@@ -147,6 +149,7 @@ def romberg(
     return y, out
 
 
+@eqx.filter_jit
 def rombergts(
     fun,
     interval,

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -267,7 +267,11 @@ class _WrappedFunction(eqx.Module):
 
     @eqx.filter_jit
     def __call__(self, x):
-        f = jnp.vectorize(self.fun, signature="()->" + self.outsig)(x, *self.args)
+        f = jnp.vectorize(
+            self.fun,
+            excluded=tuple(range(1, len(self.args) + 1)),
+            signature="()->" + self.outsig,
+        )(x, *self.args)
         return jnp.where(jnp.isfinite(f), f, 0.0)
 
 

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,5 +1,6 @@
 """Tests for adaptive quadrature routines."""
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -706,3 +707,42 @@ class TestRomberg:
         self._base(16, 1e-4)
         self._base(16, 1e-8)
         self._base(16, 1e-12)
+
+
+def test_escaped_tracers():
+    """Test that no tracers escape, related to gh issue 18."""
+
+    @jax.jit
+    def integral_quadgk(interval):
+        return quadgk(jnp.square, interval)
+
+    with jax.checking_leaks():
+        jax.block_until_ready(integral_quadgk([0.0, 1.0]))
+
+    @jax.jit
+    def integral_quadcc(interval):
+        return quadcc(jnp.square, interval)
+
+    with jax.checking_leaks():
+        jax.block_until_ready(integral_quadcc([0.0, 1.0]))
+
+    @jax.jit
+    def integral_quadts(interval):
+        return quadts(jnp.square, interval)
+
+    with jax.checking_leaks():
+        jax.block_until_ready(integral_quadts([0.0, 1.0]))
+
+    @jax.jit
+    def integral_romberg(interval):
+        return romberg(jnp.square, interval)
+
+    with jax.checking_leaks():
+        jax.block_until_ready(integral_romberg([0.0, 1.0]))
+
+    @jax.jit
+    def integral_rombergts(interval):
+        return rombergts(jnp.square, interval)
+
+    with jax.checking_leaks():
+        jax.block_until_ready(integral_rombergts([0.0, 1.0]))


### PR DESCRIPTION
Previously to map a function to the unit interval we made a new function that wraps the old ones along with the old interval, however this would lead to escaped tracer values since the interval is in general a traced value.

This now uses a custom pytree to store the original function and interval, so that they are not lost by closure.

Resolves #18 