### PR TITLE
Use better mapping for doubly infinite domains

### DIFF
--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -41,14 +41,14 @@ def _map_linear_inv(x: jax.Array, a: jax.Array, b: jax.Array):
 
 def _map_ninfinf(t: jax.Array, a: jax.Array, b: jax.Array):
     """Map a point t in [-1, 1] to x in [-inf, inf]."""
-    x = t / jnp.sqrt(1 - t**2)
-    w = 1 / jnp.sqrt(1 - t**2) ** 3
+    x = jnp.tan(t * jnp.pi / 2)
+    w = jnp.pi / 2 / jnp.cos(jnp.pi * t / 2) ** 2
     return x.squeeze(), w.squeeze()
 
 
 def _map_ninfinf_inv(x: jax.Array, a: jax.Array, b: jax.Array):
     """Map a point x in [-inf, inf] to t in [-1, 1]."""
-    t = x / jnp.sqrt(x**2 + 1)
+    t = jnp.arctan(x) / (jnp.pi / 2)
     return t.squeeze()
 
 


### PR DESCRIPTION
Previously we used `t = x/sqrt(1 + x**2)` which asymtotes like `1/x**2` which means that for integrals of `1/x^p` for `1<p<2`, the mapped integrand is singular even though the original integral over the infinite domain converges. This PR switches to using `t = arctan(x)` which asymptotes like 1/x, so any integrand decaying faster than 1/x gives a convergent integral when mapped.

For more strongly damped integrands like exponentials or gaussians, they both work fine. But the new one should work a bit better for integrands just on the verge of integrability over the doubly infinite domain.

Note than for integrals over a half infinite domain, the existing method uses a slightly different mapping which also asymptotes like `1/x` so is already correct even for things like `1/x**1.5`