### PR TITLE
Add new adjoint methods

### DIFF
--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -15,22 +15,55 @@ jobs:
     outputs:
       jax-versions: ${{ steps.discover.outputs.versions }}
     steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Read minimum supported JAX version from pyproject.toml
+        id: minimum
+        run: |
+          # Single source for the oldest version we test: the lower bound of the jax
+          # pin in project dependencies. Upper bound is still whatever the latest is on
+          # pypi, we want to test new versions as they come out before bumping
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import re
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              deps = tomllib.load(f)["project"]["dependencies"]
+
+          # `\b` keeps this from matching the "jaxlib" requirement if one is
+          # ever added alongside "jax".
+          jax = next(d for d in deps if re.match(r"^jax\b", d))
+          match = re.search(r">=\s*([0-9]+(?:\.[0-9]+)*)", jax)
+          if match is None:
+              raise SystemExit(f"no lower bound in jax requirement {jax!r}")
+
+          # normalize to major.minor.patch so the jq comparison below can treat
+          # it as a fixed length list of numbers
+          parts = (match.group(1).split(".") + ["0", "0"])[:3]
+          print(f"version={'.'.join(parts)}")
+          PY
       - name: Discover available JAX versions from PyPI
         id: discover
         run: |
-          # Fetch every stable, non-yanked JAX release >= 0.4.36 from PyPI and
-          # emit them as a JSON array for the test matrix below. Missing
-          # versions and any newly released versions are handled
+          # Fetch every stable, non-yanked JAX release >= the minimum we
+          # support from PyPI and emit them as a JSON array for the test matrix
+          # below. Missing versions and any newly released versions are handled
           # automatically. jaxlib only became pip-installable at 0.4.18, so
           # older jax cannot get a matching jaxlib here.
           versions=$(curl -s https://pypi.org/pypi/jax/json | jq -c \
-            '[.releases | to_entries[]
+            --arg min "${{ steps.minimum.outputs.version }}" \
+            '($min | split(".") | map(tonumber)) as $minimum
+             | [.releases | to_entries[]
               | select(.value | length > 0)
               | select(.value[0].yanked == false)
               | .key
               | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
-              | select((split(".") | map(tonumber)) >= [0, 4, 36])]
+              | select((split(".") | map(tonumber)) >= $minimum)]
              | sort_by(. | split(".") | map(tonumber))')
+          echo "testing jax >= ${{ steps.minimum.outputs.version }}: ${versions}"
           echo "versions=${versions}" >> "$GITHUB_OUTPUT"
 
   jax_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changelog
 
 v0.3.0
 ------
+- Added pluggable adjoints, controlling how derivatives of a quadrature are computed.
+ ``quadgk``, ``quadcc``, ``quadts``, ``romberg``, ``rombergts``, and
+ ``adaptive_quadrature`` all take a new ``adjoint`` argument, and ``AbstractAdjoint``, ``DirectAdjoint``, and ``LeibnizAdjoint`` are exported at the top level.
+  - ``DirectAdjoint`` (the default) differentiates the discretization, reusing the
+    subdivision the primal solve converged to. Matches but uses a much faster
+    implementation.
+  - ``LeibnizAdjoint`` gives the derivative its own adaptive solve, so it gets its own
+    error control rather than inheriting the subdivision chosen for the integral. Often
+    several times faster for a gradient of a scalar-valued integral.
+- Fixed a bug in the sub-interval bookkeeping causing wrong results when the number of
+  iterations reaches the max allowed (though in this case the solution is marked as
+  un-converged anyways)
+- ``vmap``-ed integrations should now be faster, by stopping evaluation once every batch
+  element has converged, rather than running for the full ``max_ninter`` iterations
+  whenever any single element still needs them. Results are unchanged.
 - **Breaking**: removed ``fixed_quadgk``, ``fixed_quadcc``, and ``fixed_quadts``,
   deprecated since v0.2.2. Use ``GaussKronrodRule``, ``ClenshawCurtisRule``, and
   ``TanhSinhRule`` instead, eg
@@ -13,6 +28,10 @@ v0.3.0
   ``quadax.AbstractQuadratureRule``.
 - **Breaking**: removed the unused ``norm`` argument to ``adaptive_quadrature``. It had
   no effect; the norm is taken from the rule, ie ``GaussKronrodRule(order, norm)``.
+- Packaging metadata moved from ``setup.py``/``setup.cfg`` into ``pyproject.toml``.
+  Development dependencies are now declared as extras rather than in requirements
+  files, so use ``pip install -e ".[dev]"`` (or the narrower ``test``, ``docs``, and
+  ``lint`` extras) when working from a checkout.
 
 
 v0.2.13

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,8 @@ quadax
 
 quadax is a library for numerical quadrature and integration using JAX.
 
-- ``vmap``-able, ``jit``-able, differentiable.
+- ``vmap``-able, ``jit``-able, differentiable in both forward and reverse mode.
+- Pluggable ``adjoint`` methods controlling how derivatives are computed.
 - Scalar or vector valued integrands.
 - Finite or infinite domains with discontinuities or singularities within the domain of integration.
 - Globally adaptive Gauss-Kronrod and Clenshaw-Curtis quadrature for smooth integrands (similar to ``scipy.integrate.quad``)
@@ -17,7 +18,6 @@ quadax is a library for numerical quadrature and integration using JAX.
 
 Coming soon:
 
-- Custom JVP/VJP rules (currently AD works by differentiating the loop which isn't the most efficient.)
 - N-D quadrature (cubature)
 - QMC methods
 - Integration with weight functions

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,22 @@ Quadrature Rules
     TanhSinhRule           -- Fixed order integration over finite interval using tanh-sinh (aka double exponential) scheme
 
 
+Adjoints
+--------
+
+Adjoints control how derivatives of a quadrature are computed, without changing what the
+quadrature itself returns. Pass one as the ``adjoint`` argument.
+
+.. autosummary::
+    :toctree: _api/
+    :recursive:
+    :template: class.rst
+
+    AbstractAdjoint       -- Abstract base class for all adjoint methods
+    DirectAdjoint         -- Exact derivative of discretized problem on the converged subdivision, aka "discretize then optimize" or "discrete adjoint" (default)
+    LeibnizAdjoint        -- Leibniz rule with an error controlled derivative solve, aka "optimize then discretize" or "continuous adjoint"
+
+
 Integrating function from sampled values
 ----------------------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,8 @@ Quadrature Rules
     TanhSinhRule           -- Fixed order integration over finite interval using tanh-sinh (aka double exponential) scheme
 
 
+.. _adjoints:
+
 Adjoints
 --------
 
@@ -46,6 +48,46 @@ quadrature itself returns. Pass one as the ``adjoint`` argument.
     AbstractAdjoint       -- Abstract base class for all adjoint methods
     DirectAdjoint         -- Exact derivative of discretized problem on the converged subdivision, aka "discretize then optimize" or "discrete adjoint" (default)
     LeibnizAdjoint        -- Leibniz rule with an error controlled derivative solve, aka "optimize then discretize" or "continuous adjoint"
+
+Choosing an adjoint
+~~~~~~~~~~~~~~~~~~~
+
+There are two, both supporting forward and reverse mode.
+
+:class:`~quadax.DirectAdjoint` is the default. It differentiates the discretization the
+primal solve settled on, so the derivative costs no error control of its own, and for a
+cheap integrand it is usually the cheaper option in either mode.
+
+:class:`~quadax.LeibnizAdjoint` instead evaluates the derivative with a second adaptive
+solve, giving it its own error control rather than inheriting the subdivision chosen for
+the integral. This buys:
+
+* **Accuracy.** When the derivative of the integrand is sharply peaked somewhere the
+  integrand itself is smooth, the subdivision that resolves the integral need not
+  resolve its derivative. On such a problem at a loose tolerance the difference can be
+  several orders of magnitude; at a tolerance tight enough that the integral's
+  subdivision resolves the derivative anyway, it may be less of an issue.
+* **Speed when the integrand is expensive.** The derivative solve stops as soon as the
+  derivative has converged, rather than covering the subdivision the integral needed, so
+  the more one evaluation of the integrand costs, the more there is to save. This
+  applies to both forward and reverse modes.
+
+Against that, its reverse pass carries the workspace of the second solve, so on a scalar
+integrand it generally costs more memory than the default; on a vector or matrix valued
+integrand, where the stored subdivision is what dominates, it can cost less.
+
+Both pick up the jump term from differentiating with respect to a breakpoint that sits
+on a discontinuity. Neither can see a discontinuity that has no breakpoint at it -
+declare one there.
+
+:func:`~quadax.romberg` and :func:`~quadax.rombergts` have no subdivision to reuse -
+``DirectAdjoint`` freezes the number of Richardson levels instead - and there the two
+cost about the same, so the choice is about accuracy alone.
+
+These are rules of thumb, not laws. The balance shifts with how expensive the integrand
+is relative to the quadrature around it, how hard its derivative is to integrate
+compared to the integrand, and how many parameters are involved. Time both on your own
+problem before caring much about the difference.
 
 
 Integrating function from sampled values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "equinox >= 0.11.0, < 0.14",
-  "jax >= 0.4.36, < 0.11",
+  "jax >= 0.5.0, < 0.11",
   "numpy >= 1.20.0, < 2.5",
 ]
 dynamic = ["version"]

--- a/quadax/__init__.py
+++ b/quadax/__init__.py
@@ -2,6 +2,7 @@
 
 from . import _version
 from .adaptive import adaptive_quadrature, quadcc, quadgk, quadts
+from .adjoint import AbstractAdjoint, DirectAdjoint, LeibnizAdjoint
 from .fixed_order import (
     AbstractQuadratureRule,
     ClenshawCurtisRule,
@@ -23,6 +24,9 @@ __all__ = [
     "GaussKronrodRule",
     "NestedRule",
     "TanhSinhRule",
+    "AbstractAdjoint",
+    "DirectAdjoint",
+    "LeibnizAdjoint",
     "romberg",
     "rombergts",
     "cumulative_simpson",

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -1,26 +1,27 @@
 """Functions for globally h-adaptive quadrature."""
 
 from collections.abc import Callable
+from functools import partial
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
 
+from .adjoint import (
+    AbstractAdjoint,
+    DirectAdjoint,
+    QuadratureOps,
+    build_integrand,
+    closure_convert,
+)
 from .fixed_order import (
     AbstractQuadratureRule,
     ClenshawCurtisRule,
     GaussKronrodRule,
     TanhSinhRule,
 )
-from .utils import (
-    QuadratureInfo,
-    _get_eps,
-    bounded_while_loop,
-    errorif,
-    map_interval,
-    wrap_func,
-)
+from .utils import QuadratureInfo, _get_eps, bounded_while_loop, errorif
 
 NORMAL_EXIT = 0
 MAX_NINTER = 1
@@ -41,6 +42,7 @@ def quadgk(
     max_ninter: int = 50,
     order: int = 21,
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
 ):
     """Global adaptive quadrature using Gauss-Kronrod rule.
 
@@ -79,6 +81,14 @@ def quadgk(
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which is gives the exact derivative of the discretized problem, supports both
+        forward and reverse mode, and is usually the fastest option.
+        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
+        (ie, can better approximate the true continuous derivative), and in reverse
+        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
+        paying for.
 
     Returns
     -------
@@ -126,6 +136,7 @@ def quadgk(
         epsabs,
         epsrel,
         max_ninter,
+        adjoint=adjoint,
     )
     info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
     return y, info
@@ -142,6 +153,7 @@ def quadcc(
     max_ninter: int = 50,
     order: int = 32,
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
 ):
     """Global adaptive quadrature using Clenshaw-Curtis rule.
 
@@ -179,6 +191,14 @@ def quadcc(
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which is gives the exact derivative of the discretized problem, supports both
+        forward and reverse mode, and is usually the fastest option.
+        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
+        (ie, can better approximate the true continuous derivative), and in reverse
+        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
+        paying for.
 
     Returns
     -------
@@ -226,6 +246,7 @@ def quadcc(
         epsabs,
         epsrel,
         max_ninter,
+        adjoint=adjoint,
     )
     info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
     return y, info
@@ -242,6 +263,7 @@ def quadts(
     max_ninter: int = 50,
     order: int = 61,
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
 ):
     """Global adaptive quadrature using trapezoidal tanh-sinh rule.
 
@@ -278,6 +300,14 @@ def quadts(
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which is gives the exact derivative of the discretized problem, supports both
+        forward and reverse mode, and is usually the fastest option.
+        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
+        (ie, can better approximate the true continuous derivative), and in reverse
+        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
+        paying for.
 
     Returns
     -------
@@ -325,6 +355,7 @@ def quadts(
         epsabs,
         epsrel,
         max_ninter,
+        adjoint=adjoint,
     )
     info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
     return y, info
@@ -340,6 +371,7 @@ def adaptive_quadrature(
     epsabs: ArrayLike | None = None,
     epsrel: ArrayLike | None = None,
     max_ninter: int = 50,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
     **kwargs,
 ):
     """Global adaptive quadrature.
@@ -371,6 +403,14 @@ def adaptive_quadrature(
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which is gives the exact derivative of the discretized problem, supports both
+        forward and reverse mode, and is usually the fastest option.
+        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
+        (ie, can better approximate the true continuous derivative), and in reverse
+        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
+        paying for.
     kwargs : dict
         Additional keyword arguments passed to ``rule``.
 
@@ -409,9 +449,11 @@ def adaptive_quadrature(
         "rule should be an instance of quadax.AbstractQuadratureRule, "
         f"got {type(rule)}",
     )
-    intfun = rule.integrate
-    _norm = rule.norm
     interval = jnp.atleast_1d(jnp.asarray(interval))
+    if not jnp.issubdtype(interval.dtype, jnp.inexact):
+        # integration limits must be inexact: they are differentiated with respect to,
+        # and integer leaves would otherwise be treated as static metadata
+        interval = interval.astype(jnp.result_type(float))
     errorif(
         max_ninter < len(interval) - 1,
         ValueError,
@@ -421,8 +463,124 @@ def adaptive_quadrature(
         epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
     if epsrel is None:
         epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
-    fun, interval = map_interval(fun, interval)
-    vfunc = wrap_func(fun, args)
+    epsabs = jnp.asarray(epsabs)
+    epsrel = jnp.asarray(epsrel)
+
+    f_conv, consts = closure_convert(fun, args)
+
+    ops = QuadratureOps(
+        build=partial(build_integrand, f_conv=f_conv),
+        solve=partial(_adaptive_solve, max_ninter=max_ninter),
+        rebuild=_rebuild_mesh,
+        on_mesh=_quad_on_mesh,
+        frozen=_frozen_mesh,
+        frozen_solve=_mesh_solve,
+    )
+    y, state = adjoint.quadrature(
+        ops, rule, interval, args, consts, epsabs, epsrel, kwargs
+    )
+
+    err = state["err_sum"]
+    neval = state["neval"]
+    status = state["status"]
+    info = state if full_output else None
+    out = QuadratureInfo(err, neval, status, info)
+    return y, out
+
+
+# How many sub-intervals of a fixed subdivision are evaluated at once. Evaluating all of
+# them together is fastest but makes peak memory scale with ``max_ninter``, which is a
+# safety bound users tend to set generously; evaluating one at a time streams but
+# serializes. Measured on a scalar integrand with an order 21 rule, 8 is where the curve
+# turns over: it matches one-at-a-time peak memory at large ``max_ninter`` while being
+# noticeably faster in reverse mode, and larger blocks buy little more speed for a lot
+# more memory.
+_CHUNK = 8
+
+
+def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
+    """Apply the local rule on a fixed subdivision and sum the contributions.
+
+    Sub-intervals are independent, so they are evaluated in blocks: ``vmap`` within a
+    block, ``scan`` across blocks. A plain ``scan`` over every sub-interval would make a
+    gradient cost ``max_ninter`` rather than the number of sub-intervals actually used,
+    because reverse mode stacks residuals for every iteration whether or not it did any
+    work. A plain ``vmap`` fixes that but materializes the whole subdivision at once.
+
+    Slots past the end of the subdivision are empty (``a == b``). They are handed a real
+    sub-interval and masked out afterwards rather than skipped with a ``cond``: under
+    ``vmap`` a batched ``cond`` becomes a ``select`` carrying a ``stop_gradient`` that
+    cannot be transposed. Substituting a real sub-interval also stops an integrand that
+    is singular somewhere in the mapped domain from poisoning the unused slots with a
+    NaN that the mask would then propagate.
+    """
+    del kwargs
+    used = a_arr != b_arr
+    a_safe = jnp.where(used, a_arr, a_arr[0])
+    b_safe = jnp.where(used, b_arr, b_arr[0])
+
+    nslot = a_arr.shape[0]
+    chunk = min(_CHUNK, nslot)
+    pad = -nslot % chunk
+    reshape = lambda x, fill: jnp.pad(x, (0, pad), constant_values=fill).reshape(
+        -1, chunk
+    )
+    a_c, b_c = reshape(a_safe, a_arr[0]), reshape(b_safe, b_arr[0])
+    used_c = reshape(used.astype(a_arr.dtype), 0.0)
+
+    apply1 = lambda a, b: rule._apply(vfunc, a, b, ())
+    sds = jax.eval_shape(apply1, a_arr[0], b_arr[0])
+
+    def bodyfun(total, block):
+        a, b, m = block
+        y = jax.vmap(apply1)(a, b)
+        y = y * m.reshape((-1,) + (1,) * (y.ndim - 1))
+        return total + jnp.sum(y, axis=0), None
+
+    if checkpoint:
+        # Recompute each block during the backward pass instead of keeping the
+        # integrand's value at every node of every sub-interval. Those values dominate
+        # reverse mode otherwise, and recomputing them is nearly free here.
+        bodyfun = jax.checkpoint(bodyfun)
+
+    total, _ = jax.lax.scan(
+        bodyfun, jnp.zeros(sds.shape, sds.dtype), (a_c, b_c, used_c)
+    )
+    return total
+
+
+def _frozen_mesh(state):
+    """The parts of the subdivision that do not vary smoothly with the limits."""
+    return (state["owner"], state["frac_a"], state["frac_b"])
+
+
+def _mesh_solve(rule, vfunc, interval, frozen, kwargs, *, checkpoint=True):
+    """Quadrature on the subdivision implied by `frozen`, as a function of interval."""
+    a_arr, b_arr = _rebuild_mesh(interval, frozen)
+    return _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, checkpoint=checkpoint)
+
+
+def _rebuild_mesh(interval, frozen):
+    """Rebuild the subdivision from `interval`, as a function of the integration limits.
+
+    Bisection never crosses a breakpoint, so every sub-interval stays inside whichever
+    of the original sub-intervals it was carved out of, at a fixed dyadic fraction of
+    the way along it. The primal loop records that owner and those fractions, which are
+    exactly the parts that do not vary smoothly. Rebuilding the mesh is then a gather
+    and a rescale, no loop, and no dependence on how many bisections were performed,
+    while still letting the mesh move when a limit or a breakpoint moves.
+    """
+    owner, frac_a, frac_b = frozen
+    lo = interval[owner]
+    hi = interval[owner + 1]
+    width = hi - lo
+    return lo + frac_a * width, lo + frac_b * width
+
+
+def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter):
+    """Run the globally adaptive subdivision loop."""
+    intfun = partial(rule.integrate, **kwargs) if kwargs else rule.integrate
+    _norm = rule.norm
     f = jax.eval_shape(vfunc, (interval[0] + interval[-1]) / 2)
     epmach = _get_eps(f)
     shape = f.shape
@@ -447,12 +605,23 @@ def adaptive_quadrature(
     state["err_bnd"] = 0.0  # error bound we're trying to reach
     state["area"] = jnp.zeros(shape, f.dtype)  # current best estimate for I
     state["err_sum"] = 0.0  # current estimate for error in I
+    # Where each sub-interval sits relative to the *original* sub-intervals: which one
+    # it was carved out of, and the fractions of the way along it that its ends lie at.
+    # These are what stay fixed when a limit or breakpoint moves, so recording them lets
+    # the mesh be rebuilt as a smooth function of `interval` by gather and rescale.
+    state["owner"] = (
+        jnp.zeros(max_ninter, int)
+        .at[: state["ninter"]]
+        .set(jnp.arange(state["ninter"]))
+    )
+    state["frac_a"] = jnp.zeros(max_ninter)
+    state["frac_b"] = jnp.zeros(max_ninter).at[: state["ninter"]].set(1.0)
 
     def init_body(i, state_):
         state, intabs_ = state_
         a = state["a_arr"][i]
         b = state["b_arr"][i]
-        result, abserr, intabs, intmmn = intfun(vfunc, a, b, (), **kwargs)
+        result, abserr, intabs, intmmn = intfun(vfunc, a, b, ())
 
         intabs_ += intabs
         state["neval"] += 1
@@ -484,24 +653,26 @@ def adaptive_quadrature(
         )
 
     def bodyfun(state):
-        state["ninter"] += 1
-
         # bisect the sub-interval with the largest error estimate.
         i = jnp.argmax(state["e_arr"])
+        # The bisection turns one sub-interval into two, so the extra half goes in the
+        # first free slot, which is the *current* interval count, before incrementing
+        # it. Taking the count after the increment instead would skip a slot and, on the
+        # final iteration, index off the end of the arrays, silently dropping that half
+        # of the interval from the result.
         n = state["ninter"]
+        state["ninter"] += 1
         a1 = state["a_arr"][i]
         b1 = 0.5 * (state["a_arr"][i] + state["b_arr"][i])
         a2 = b1
         b2 = state["b_arr"][i]
 
-        area1, error1, intabs1, intmmn1 = intfun(vfunc, a1, b1, (), **kwargs)
+        area1, error1, intabs1, intmmn1 = intfun(vfunc, a1, b1, ())
         state["neval"] += 1
-        area2, error2, intabs2, intmmn2 = intfun(vfunc, a2, b2, (), **kwargs)
+        area2, error2, intabs2, intmmn2 = intfun(vfunc, a2, b2, ())
         state["neval"] += 1
 
-        # ! improve previous approximations to integral
-        # ! and error and test for accuracy.
-
+        # improve previous approximations to integral and error and test for accuracy.
         area12 = area1 + area2
         erro12 = error1 + error2
         state["err_sum"] += erro12 - state["e_arr"][i]
@@ -517,7 +688,9 @@ def adaptive_quadrature(
             _norm(state["r_arr"][i] - area12) <= 0.1e-4 * _norm(area12)
         ) & (erro12 >= 0.99 * jnp.max(state["e_arr"]))
         # are errors getting larger as we go to smaller intervals?
-        state["roundoff2"] += (n > 10) & (erro12 > jnp.max(state["e_arr"]))
+        state["roundoff2"] += (state["ninter"] > 10) & (
+            erro12 > jnp.max(state["e_arr"])
+        )
         state["status"] += 2**ROUNDOFF * (
             (state["roundoff1"] >= 10) | (state["roundoff2"] >= 20)
         )
@@ -532,12 +705,23 @@ def adaptive_quadrature(
 
         # update the arrays of interval starts/ends etc
 
+        # both halves stay inside whichever original sub-interval this one came from,
+        # splitting its span at the midpoint of the fractions
+        owner_i = state["owner"][i]
+        frac_a1 = state["frac_a"][i]
+        frac_b2 = state["frac_b"][i]
+        frac_mid = 0.5 * (frac_a1 + frac_b2)
+        state["owner"] = state["owner"].at[n].set(owner_i)
+
         def error1big(state):
             state["a_arr"] = state["a_arr"].at[n].set(a2)
             state["b_arr"] = state["b_arr"].at[i].set(b1)
             state["b_arr"] = state["b_arr"].at[n].set(b2)
             state["e_arr"] = state["e_arr"].at[i].set(error1)
             state["e_arr"] = state["e_arr"].at[n].set(error2)
+            state["frac_b"] = state["frac_b"].at[i].set(frac_mid)
+            state["frac_a"] = state["frac_a"].at[n].set(frac_mid)
+            state["frac_b"] = state["frac_b"].at[n].set(frac_b2)
             return state
 
         def error2big(state):
@@ -548,6 +732,9 @@ def adaptive_quadrature(
             state["r_arr"] = state["r_arr"].at[n].set(area1)
             state["e_arr"] = state["e_arr"].at[i].set(error2)
             state["e_arr"] = state["e_arr"].at[n].set(error1)
+            state["frac_a"] = state["frac_a"].at[i].set(frac_mid)
+            state["frac_a"] = state["frac_a"].at[n].set(frac_a1)
+            state["frac_b"] = state["frac_b"].at[n].set(frac_mid)
             return state
 
         state = jax.lax.cond(error2 > error1, error2big, error1big, state)
@@ -556,9 +743,4 @@ def adaptive_quadrature(
     state = bounded_while_loop(condfun, bodyfun, state, max_ninter + 1)
 
     y = jnp.sum(state["r_arr"], axis=0)
-    err = state["err_sum"]
-    neval = state["neval"]
-    status = state["status"]
-    info = state if full_output else None
-    out = QuadratureInfo(err, neval, status, info)
-    return y, out
+    return y, state

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -6,6 +6,7 @@ from functools import partial
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from equinox.internal import unvmap_any
 from jax.typing import ArrayLike
 
 from .adjoint import (
@@ -83,12 +84,12 @@ def quadgk(
         should be callable.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which is gives the exact derivative of the discretized problem, supports both
-        forward and reverse mode, and is usually the fastest option.
-        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
-        (ie, can better approximate the true continuous derivative), and in reverse
-        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
-        paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
 
     Returns
     -------
@@ -193,12 +194,12 @@ def quadcc(
         should be callable.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which is gives the exact derivative of the discretized problem, supports both
-        forward and reverse mode, and is usually the fastest option.
-        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
-        (ie, can better approximate the true continuous derivative), and in reverse
-        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
-        paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
 
     Returns
     -------
@@ -302,12 +303,12 @@ def quadts(
         should be callable.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which is gives the exact derivative of the discretized problem, supports both
-        forward and reverse mode, and is usually the fastest option.
-        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
-        (ie, can better approximate the true continuous derivative), and in reverse
-        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
-        paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
 
     Returns
     -------
@@ -405,12 +406,12 @@ def adaptive_quadrature(
         algorithm.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which is gives the exact derivative of the discretized problem, supports both
-        forward and reverse mode, and is usually the fastest option.
-        ``LeibnizAdjoint`` is slower but gives the derivative its own error control
-        (ie, can better approximate the true continuous derivative), and in reverse
-        mode uses much less memory; see ``AbstractAdjoint`` for when that is worth
-        paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
     kwargs : dict
         Additional keyword arguments passed to ``rule``.
 
@@ -499,21 +500,30 @@ _CHUNK = 8
 
 
 def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
-    """Apply the local rule on a fixed subdivision and sum the contributions.
+    """Apply the local rule on a fixed subdivision and sum the contributions."""
+    # Sub-intervals are independent, so they are evaluated in blocks: ``vmap`` within a
+    # block, ``scan`` across blocks. A plain ``scan`` over every sub-interval would make
+    # a gradient cost ``max_ninter`` rather than the number of sub-intervals actually
+    # used, because reverse mode stacks residuals for every iteration whether or not it
+    # did any work. A plain ``vmap`` fixes that but materializes the whole subdivision
+    # at once.
 
-    Sub-intervals are independent, so they are evaluated in blocks: ``vmap`` within a
-    block, ``scan`` across blocks. A plain ``scan`` over every sub-interval would make a
-    gradient cost ``max_ninter`` rather than the number of sub-intervals actually used,
-    because reverse mode stacks residuals for every iteration whether or not it did any
-    work. A plain ``vmap`` fixes that but materializes the whole subdivision at once.
+    # Slots past the end of the subdivision are empty (``a == b``). A block with no used
+    # slot in it is skipped entirely with a ``cond``, which is what keeps the cost of a
+    # derivative tracking the sub-intervals the solve actually used rather than
+    # ``max_ninter``; the solve fills slots from the front, so the used blocks are the
+    # leading ones. The predicate is reduced with ``unvmap_any`` so that it stays a
+    # scalar under ``vmap`` and the skip survives batching, at the cost of a block being
+    # evaluated for every batch element as soon as one of them needs it.
 
-    Slots past the end of the subdivision are empty (``a == b``). They are handed a real
-    sub-interval and masked out afterwards rather than skipped with a ``cond``: under
-    ``vmap`` a batched ``cond`` becomes a ``select`` carrying a ``stop_gradient`` that
-    cannot be transposed. Substituting a real sub-interval also stops an integrand that
-    is singular somewhere in the mapped domain from poisoning the unused slots with a
-    NaN that the mask would then propagate.
-    """
+    # Within a block the empty slots are still handed a real sub-interval and masked out
+    # afterwards rather than skipped: a per-slot ``cond`` sits inside the ``vmap``,
+    # where a batched ``cond`` becomes a ``select`` carrying a ``stop_gradient`` that
+    # cannot be transposed. Substituting a real sub-interval also stops an integrand
+    # that is singular somewhere in the mapped domain from poisoning the unused slots
+    # with a NaN that the mask would then propagate. So the granularity of the skip is
+    # ``_CHUNK``.
+
     del kwargs
     used = a_arr != b_arr
     a_safe = jnp.where(used, a_arr, a_arr[0])
@@ -533,9 +543,23 @@ def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
 
     def bodyfun(total, block):
         a, b, m = block
-        y = jax.vmap(apply1)(a, b)
-        y = y * m.reshape((-1,) + (1,) * (y.ndim - 1))
-        return total + jnp.sum(y, axis=0), None
+
+        def evaluate(_):
+            y = jax.vmap(apply1)(a, b)
+            y = y * m.reshape((-1,) + (1,) * (y.ndim - 1))
+            return jnp.sum(y, axis=0)
+
+        # `unvmap_any` keeps the predicate a scalar under `vmap`, so the block is
+        # skipped whenever *no* batch element uses it instead of degrading to a select
+        # that evaluates every block. No inner per-element gate is needed: `m` already
+        # zeroes the slots an individual element does not use.
+        contrib = jax.lax.cond(
+            unvmap_any(jnp.any(m != 0)),
+            evaluate,
+            lambda _: jnp.zeros(sds.shape, sds.dtype),
+            None,
+        )
+        return total + contrib, None
 
     if checkpoint:
         # Recompute each block during the backward pass instead of keeping the

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -239,8 +239,8 @@ class DirectAdjoint(AbstractAdjoint):
     the derivative is then taken of that discretization.
 
     This is the default. It is usually the fastest option for forward mode. For a
-    gradient of a scalar-valued integral via ``jax.grad`, :class:`LeibnizAdjoint` can be
-    often several times faster; see :class:`AbstractAdjoint` for the trade-offs.
+    gradient of a scalar-valued integral via ``jax.grad``, :class:`LeibnizAdjoint` can
+    be often several times faster; see :class:`AbstractAdjoint` for the trade-offs.
 
     It works by running the primal solve recording the final adaptive mesh, and then
     using the same mesh (with corrections when differentiating the interval itself) to
@@ -250,6 +250,12 @@ class DirectAdjoint(AbstractAdjoint):
     extra integrand evaluations are spent on error control for it. That is what makes
     this the cheapest option, and also the reason to reach for a Leibniz adjoint when
     the derivative needs resolving that the integral did not pay for.
+
+    Methods with no subdivision to reuse (Romberg) are handled the same way in spirit:
+    the number of Richardson levels the solve settled on is frozen instead of a mesh.
+    There the fixed discretization still contains a ``fori_loop`` with dynamic bounds
+    that JAX cannot reverse differentiate, so the derivative is routed through a custom
+    primitive that supplies the two directions explicitly. Both modes work either way.
 
     Parameters
     ----------
@@ -266,11 +272,6 @@ class DirectAdjoint(AbstractAdjoint):
         only the derivative with respect to the integration limits, since its derivative
         with respect to ``args`` comes from a separate solve that stores nothing.
 
-    Methods with no subdivision to reuse (Romberg) are handled the same way in spirit:
-    the number of Richardson levels the solve settled on is frozen instead of a mesh.
-    There the fixed discretization still contains a ``fori_loop`` with dynamic bounds
-    that JAX cannot reverse differentiate, so the derivative is routed through a custom
-    primitive that supplies the two directions explicitly. Both modes work either way.
     """
 
     checkpoint: bool = True
@@ -536,14 +537,15 @@ class LeibnizAdjoint(AbstractAdjoint):
     control rather than inheriting the subdivision chosen for the integral -- see
     :class:`AbstractAdjoint` for when that is worth paying for.
 
-    Both modes come from one object: the integral carries a custom JVP whose tangent is
-    a primitive that is linear in the tangent and supplies an explicit transpose, so JAX
-    takes forward mode from the rule and reverse mode by transposing it.
+    Because each mode picks its own subdivision, forward and reverse results agree to
+    quadrature accuracy rather than exactly.
 
-    Only the direction being asked for is computed. Forward mode integrates the scalar
-    :math:`\partial f/\partial\theta \cdot \dot\theta`; reverse mode integrates the
-    vector-valued :math:`\bar y \cdot \partial f/\partial\theta`. Neither forms the full
-    Jacobian.
+    Derivatives with respect to the integration limits are taken on the subdivision the
+    primal solve settled on, rather than from the error-controlled solve. In mapped
+    coordinates a moving breakpoint slides a discontinuity across a fixed mesh, and
+    integrating ``df/dx`` cannot represent the resulting delta; rebuilding the mesh from
+    the limits tracks the breakpoint and recovers the jump term. Only the derivative
+    with respect to ``args`` gets its own error control.
 
     Parameters
     ----------
@@ -559,16 +561,6 @@ class LeibnizAdjoint(AbstractAdjoint):
         for :class:`DirectAdjoint` that is the whole of it, for :class:`LeibnizAdjoint`
         only the derivative with respect to the integration limits, since its derivative
         with respect to ``args`` comes from a separate solve that stores nothing.
-
-    Because each mode picks its own subdivision, forward and reverse results agree to
-    quadrature accuracy rather than exactly.
-
-    Derivatives with respect to the integration limits are taken on the subdivision the
-    primal solve settled on, rather than from the error-controlled solve. In mapped
-    coordinates a moving breakpoint slides a discontinuity across a fixed mesh, and
-    integrating ``df/dx`` cannot represent the resulting delta; rebuilding the mesh from
-    the limits tracks the breakpoint and recovers the jump term. Only the derivative
-    with respect to ``args`` gets its own error control.
     """
 
     checkpoint: bool = True

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -145,42 +145,8 @@ class AbstractAdjoint(eqx.Module):
     which runs the primal solve and attaches whatever custom differentiation rule it
     wants.
 
-    Notes
-    -----
-    There are two, both supporting forward and reverse mode.
-
-    :class:`DirectAdjoint` is the default. It differentiates the discretization the
-    primal solve settled on, so it spends no extra integrand evaluations on the
-    derivative and is the fastest option in forward mode.
-
-    :class:`LeibnizAdjoint` instead evaluates the derivative with a second adaptive
-    solve, giving it its own error control rather than inheriting the subdivision chosen
-    for the integral. This buys:
-
-    * **Accuracy.** When the derivative of the integrand is sharply peaked somewhere the
-      integrand itself is smooth, the subdivision that resolves the integral need not
-      resolve its derivative. On such a problem at a loose tolerance the difference can
-      be several orders of magnitude; at a tolerance tight enough that the integral's
-      subdivision resolves the derivative anyway, it may be less of an issue.
-    * **Speed of gradients.** Reverse mode through the quadrature is expensive and gets
-      more so as ``max_ninter`` grows, while evaluating the adjoint integral does not,
-      so ``jax.grad`` of a scalar-valued integral is often several times faster and can
-      be far more than that when the integrand is expensive.
-
-    Both pick up the jump term from differentiating with respect to a breakpoint that
-    sits on a discontinuity. Neither can see a discontinuity that has no breakpoint at
-    it -- declare one there.
-
-    These are rules of thumb, not laws. The balance shifts with how expensive the
-    integrand is relative to the quadrature around it, how hard its derivative is to
-    integrate compared to the integrand, and how many parameters are involved. Time both
-    on your own problem before caring much about the difference.
-
-    Whichever you pick, ``max_ninter`` costs something even on a problem that converges
-    immediately, because the sub-interval arrays are sized by it rather than by the
-    number of sub-intervals actually used. With ``checkpoint`` left on that cost is
-    modest, but it is not zero, so prefer sizing it to the problem over leaving it
-    generous.
+    See the Adjoints section of the API documentation for the adjoints quadax ships and
+    how to choose between them.
     """
 
     @abc.abstractmethod
@@ -246,18 +212,20 @@ class DirectAdjoint(AbstractAdjoint):
     Commonly called "discretize then optimize": the quadrature is discretized first, and
     the derivative is then taken of that discretization.
 
-    This is the default. It is usually the fastest option for forward mode. For a
-    gradient of a scalar-valued integral via ``jax.grad``, :class:`LeibnizAdjoint` can
-    be often several times faster; see :class:`AbstractAdjoint` for the trade-offs.
+    This is the default, and is the cheaper option for a cheap integrand in either mode.
+    When one evaluation of the integrand is expensive, :class:`LeibnizAdjoint` can be an
+    order of magnitude faster or more; see the Adjoints section of the API documentation
+    for the trade-offs.
 
     It works by running the primal solve recording the final adaptive mesh, and then
     using the same mesh (with corrections when differentiating the interval itself) to
     integrate the derivative of the integrand.
 
     The derivative therefore inherits the subdivision chosen for the integral, and no
-    extra integrand evaluations are spent on error control for it. That is what makes
-    this the cheapest option, and also the reason to reach for a Leibniz adjoint when
-    the derivative needs resolving that the integral did not pay for.
+    error control of its own is paid for. That is the reason to reach for a Leibniz
+    adjoint when the derivative needs resolving that the integral did not pay for, and
+    the reason a derivative costs roughly what the converged subdivision costs however
+    generous ``max_ninter`` was.
 
     Methods with no subdivision to reuse (Romberg) are handled the same way in spirit:
     the number of Richardson levels the solve settled on is frozen instead of a mesh.
@@ -272,13 +240,11 @@ class DirectAdjoint(AbstractAdjoint):
         backward pass rather than storing it. Without it reverse mode keeps the
         integrand's value at every node of every sub-interval, which dominates its
         memory and grows with ``max_ninter`` however few sub-intervals are really used;
-        recomputing cuts that by a factor of ten or more and is usually also faster,
-        so it is on by default. Turn it off when the integrand is expensive enough that
-        evaluating it twice costs more than storing the results. No effect in forward
-        mode. Applies to whatever part of a derivative is taken on a fixed subdivision:
-        for :class:`DirectAdjoint` that is the whole of it, for :class:`LeibnizAdjoint`
-        only the derivative with respect to the integration limits, since its derivative
-        with respect to ``args`` comes from a separate solve that stores nothing.
+        recomputing cuts that by around 3x at the default budget and by 30x or more
+        when ``max_ninter`` is generous, at no measured cost in speed, so it is on by
+        default. Turning it off has not been found to pay for itself even on integrands
+        costing megaflops per evaluation, so treat it mainly as a diagnostic knob. No
+        effect in forward mode.
 
     """
 
@@ -357,15 +323,29 @@ _leibniz_p = Primitive("quadax_leibniz_tangent")
 
 
 def _leibniz_unpack(flat, n, treedef, static, frozen_treedef):
-    """Split the operands back into (tangent, primal, frozen discretization)."""
+    """Split the operands into (tangent, differentiable primal, primal, frozen)."""
+    # ``treedef`` is the authority on which leaves are differentiable. It was recorded
+    # when the primitive was bound, and the tangent, the residuals and the cotangents
+    # all use it, so the three stay in step by construction.
+
+    # Recovering that structure from the operand *values* instead -- filtering the
+    # reassembled primals for inexact arrays -- looks equivalent but is not. An operand
+    # that was a concrete python float at bind time (a tolerance passed as
+    # ``epsabs=1e-8`` rather than left to default) becomes a jaxpr literal, and
+    # ``backward_pass`` hands literals back as raw python floats. Filtering drops them,
+    # and the transpose rule then returns fewer cotangents than the primitive has linear
+    # operands, which JAX reports as "foreach() argument 2 is shorter than argument 1".
+    # Hence ``jnp.asarray``: the residuals are all inexact by construction, so promoting
+    # a literal back to an array just undoes the unwrapping.
+
     tangent = jax.tree.unflatten(treedef, list(flat[:n]))
-    dyn = jax.tree.unflatten(treedef, list(flat[n : 2 * n]))
+    dyn = jax.tree.unflatten(treedef, [jnp.asarray(x) for x in flat[n : 2 * n]])
     frozen = (
         None
         if frozen_treedef is None
         else jax.tree.unflatten(frozen_treedef, list(flat[2 * n :]))
     )
-    return tangent, eqx.combine(dyn, static), frozen
+    return tangent, dyn, eqx.combine(dyn, static), frozen
 
 
 def _run_solve(ops, rule, integrand, interval_t, epsabs, epsrel, kwargs, frozen):
@@ -388,10 +368,11 @@ def _leibniz_impl(
     out_sds,
 ):
     """Forward direction: integrate the tangent of the mapped integrand."""
-    dyn_t, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
+    dyn_t, dyn, primals, frozen = _leibniz_unpack(
+        flat, n, treedef, static, frozen_treedef
+    )
     rule, interval, args, consts, epsabs, epsrel = primals
     kwargs = dict(kwargs_items)
-    dyn = eqx.filter(primals, eqx.is_inexact_array)
     _, interval_t = ops.build(interval, args, consts)
 
     def dvfunc(t):
@@ -474,10 +455,9 @@ def _leibniz_transpose(
 ):
     """Reverse direction: integrate the cotangent of the mapped integrand."""
     del out_sds
-    _, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
+    _, dyn, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
     rule, interval, args, consts, epsabs, epsrel = primals
     kwargs = dict(kwargs_items)
-    dyn = eqx.filter(primals, eqx.is_inexact_array)
     _, interval_t = ops.build(interval, args, consts)
     _, unravel = ravel_pytree(dyn)
 
@@ -542,8 +522,8 @@ class LeibnizAdjoint(AbstractAdjoint):
     r"""Differentiate by the Leibniz rule, either mode, with its own error control.
 
     The derivative is evaluated with its own adaptive solve, so it gets its own error
-    control rather than inheriting the subdivision chosen for the integral -- see
-    :class:`AbstractAdjoint` for when that is worth paying for.
+    control rather than inheriting the subdivision chosen for the integral, see the
+    Adjoints section of the API documentation for when that is worth paying for.
 
     Because each mode picks its own subdivision, forward and reverse results agree to
     quadrature accuracy rather than exactly.
@@ -562,13 +542,11 @@ class LeibnizAdjoint(AbstractAdjoint):
         backward pass rather than storing it. Without it reverse mode keeps the
         integrand's value at every node of every sub-interval, which dominates its
         memory and grows with ``max_ninter`` however few sub-intervals are really used;
-        recomputing cuts that by a factor of ten or more and is usually also faster,
-        so it is on by default. Turn it off when the integrand is expensive enough that
-        evaluating it twice costs more than storing the results. No effect in forward
-        mode. Applies to whatever part of a derivative is taken on a fixed subdivision:
-        for :class:`DirectAdjoint` that is the whole of it, for :class:`LeibnizAdjoint`
-        only the derivative with respect to the integration limits, since its derivative
-        with respect to ``args`` comes from a separate solve that stores nothing.
+        recomputing cuts that by around 3x at the default budget and by 30x or more
+        when ``max_ninter`` is generous, at no measured cost in speed, so it is on by
+        default. Turning it off has not been found to pay for itself even on integrands
+        costing megaflops per evaluation, so treat it mainly as a diagnostic knob. No
+        effect in forward mode.
     """
 
     checkpoint: bool = True

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -1,0 +1,634 @@
+"""Adjoint methods controlling how derivatives of quadrature are computed."""
+
+import abc
+from collections.abc import Callable
+from functools import partial
+from typing import NamedTuple
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax._src import core as jcore
+from jax.extend.core import Primitive
+from jax.flatten_util import ravel_pytree
+from jax.interpreters import ad, batching, mlir
+
+from .fixed_order import AbstractQuadratureRule
+from .utils import map_interval, wrap_func
+
+
+class _ConvertedFunction(eqx.Module):
+    """Closure-converted integrand, with args and hoisted constants bound."""
+
+    f_conv: Callable
+    args: tuple
+    consts: tuple
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.f_conv(x, self.args, *self.consts)
+
+
+def closure_convert(fun, args):
+    """Hoist values closed over by ``fun`` so that they are visible to AD.
+
+    Custom derivative rules only see their explicit arguments. Anything ``fun`` closes
+    over would otherwise silently get a zero gradient, so pull it out into ``consts``
+    and pass it in explicitly.
+    """
+    f_conv, consts = jax.closure_convert(
+        lambda x, args_: fun(x, *args_), jnp.array(0.0), args
+    )
+    return f_conv, tuple(consts)
+
+
+def build_integrand(interval, args, consts, *, f_conv):
+    """Map the integrand to the reference domain and wrap it for vectorization."""
+    fun = _ConvertedFunction(f_conv, args, consts)
+    fun_mapped, interval_t = map_interval(fun, interval)
+    return wrap_func(fun_mapped, ()), interval_t
+
+
+class QuadratureOps(NamedTuple):
+    """Primitive operations that an adjoint composes to build a quadrature.
+
+    This is an internal plumbing object, constructed by ``adaptive_quadrature`` and
+    ``romberg``. All fields are static (they close over no traced values), so they may
+    be passed to a custom derivative rule as a non-differentiable keyword argument.
+
+    Parameters
+    ----------
+    build : callable
+        ``build(interval, args, consts) -> (vfunc, interval_t)``. Maps the integrand to
+        the reference domain and wraps it for vectorized evaluation.
+    solve : callable
+        ``solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs) -> (y, state)``. Runs
+        the full (adaptive) quadrature.
+    rebuild : callable or None
+        ``rebuild(interval_t, state) -> (a_arr, b_arr)``. Rebuilds the subdivision from
+        ``interval_t`` using the owner/fraction bookkeeping recorded in ``state``, so
+        that the mesh carries correct derivatives with respect to the integration
+        limits. ``None`` for methods that have no subdivision (e.g. Romberg).
+    on_mesh : callable or None
+        ``on_mesh(rule, vfunc, a_arr, b_arr, kwargs) -> y``. Applies the local rule on a
+        given subdivision. ``None`` for methods that have no subdivision.
+    frozen : callable or None
+        ``frozen(state) -> discretization``. Extracts whatever the primal solve settled
+        on, for methods whose fixed-discretization evaluation JAX cannot differentiate
+        in reverse (Romberg, whose level loop has dynamic bounds). Set together with
+        ``frozen_solve``; when both are set ``DirectAdjoint`` routes through a custom
+        primitive instead of differentiating the evaluation directly.
+    frozen_solve : callable or None
+        ``frozen_solve(rule, vfunc, interval_t, discretization, kwargs) -> y``.
+        Evaluates the quadrature on a fixed discretization.
+    """
+
+    build: Callable
+    solve: Callable
+    rebuild: Callable | None = None
+    on_mesh: Callable | None = None
+    frozen: Callable | None = None
+    frozen_solve: Callable | None = None
+
+
+def _with_checkpoint(ops, checkpoint):
+    """Thread the checkpointing choice down to the fixed-subdivision quadrature."""
+    upd = {}
+    if ops.on_mesh is not None:
+        upd["on_mesh"] = partial(ops.on_mesh, checkpoint=checkpoint)
+    if ops.rebuild is not None and ops.frozen_solve is not None:
+        upd["frozen_solve"] = partial(ops.frozen_solve, checkpoint=checkpoint)
+    return ops._replace(**upd) if upd else ops
+
+
+def _zero_tangent(tree):
+    """Zero tangent for a pytree, using None for non-inexact leaves."""
+
+    def z(x):
+        x = jnp.asarray(x)
+        if jnp.issubdtype(x.dtype, jnp.inexact):
+            return jnp.zeros_like(x)
+        return None
+
+    return jax.tree.map(z, tree)
+
+
+def _fill_tangents(dyn, tangents):
+    """Replace ``None`` tangents (undifferentiated arguments) with explicit zeros.
+
+    ``eqx.filter_custom_jvp`` hands us ``None`` in place of the tangent of anything that
+    is not being differentiated (possibly deep inside a pytree) but ``jax.jvp``
+    requires a tangent for every primal, so fill those in with zeros.
+    """
+    is_none = lambda x: x is None
+    dyn_leaves, treedef = jax.tree.flatten(dyn, is_leaf=is_none)
+    tan_leaves = jax.tree.flatten(tangents, is_leaf=is_none)[0]
+    filled = [
+        None if d is None else (jnp.zeros_like(d) if t is None else t)
+        for d, t in zip(dyn_leaves, tan_leaves)
+    ]
+    return jax.tree.unflatten(treedef, filled)
+
+
+class AbstractAdjoint(eqx.Module):
+    """Abstract base class for adjoint methods.
+
+    An adjoint determines *how* derivatives of a quadrature are computed, without
+    changing what the quadrature itself returns. Subclasses implement ``quadrature``,
+    which runs the primal solve and attaches whatever custom differentiation rule it
+    wants.
+
+    Notes
+    -----
+    There are two, both supporting forward and reverse mode.
+
+    :class:`DirectAdjoint` is the default. It differentiates the discretization the
+    primal solve settled on, so it spends no extra integrand evaluations on the
+    derivative and is the fastest option in forward mode.
+
+    :class:`LeibnizAdjoint` instead evaluates the derivative with a second adaptive
+    solve, giving it its own error control rather than inheriting the subdivision chosen
+    for the integral. This buys:
+
+    * **Accuracy.** When the derivative of the integrand is sharply peaked somewhere the
+      integrand itself is smooth, the subdivision that resolves the integral need not
+      resolve its derivative. On such a problem at a loose tolerance the difference can
+      be several orders of magnitude; at a tolerance tight enough that the integral's
+      subdivision resolves the derivative anyway, it may be less of an issue.
+    * **Speed of gradients.** Reverse mode through the quadrature is expensive and gets
+      more so as ``max_ninter`` grows, while evaluating the adjoint integral does not,
+      so ``jax.grad`` of a scalar-valued integral is often several times faster and can
+      be far more than that when the integrand is expensive.
+
+    Both pick up the jump term from differentiating with respect to a breakpoint that
+    sits on a discontinuity. Neither can see a discontinuity that has no breakpoint at
+    it -- declare one there.
+
+    These are rules of thumb, not laws. The balance shifts with how expensive the
+    integrand is relative to the quadrature around it, how hard its derivative is to
+    integrate compared to the integrand, and how many parameters are involved. Time both
+    on your own problem before caring much about the difference.
+
+    Whichever you pick, ``max_ninter`` costs something even on a problem that converges
+    immediately, because the sub-interval arrays are sized by it rather than by the
+    number of sub-intervals actually used. With ``checkpoint`` left on that cost is
+    modest, but it is not zero, so prefer sizing it to the problem over leaving it
+    generous.
+    """
+
+    @abc.abstractmethod
+    def quadrature(
+        self,
+        ops: QuadratureOps,
+        rule: AbstractQuadratureRule | None,
+        interval: jax.Array,
+        args: tuple,
+        consts: tuple,
+        epsabs: jax.Array,
+        epsrel: jax.Array,
+        kwargs: dict,
+    ) -> tuple[jax.Array, dict]:
+        """Evaluate the quadrature and define how it is differentiated.
+
+        Parameters
+        ----------
+        ops : QuadratureOps
+            Primitive operations for this quadrature method.
+        rule : AbstractQuadratureRule
+            Local quadrature rule. Ignored by methods that do not use one.
+        interval : jax.Array
+            Limits of integration with possible breakpoints, in the original
+            (unmapped) coordinates.
+        args : tuple
+            Extra arguments to the integrand.
+        consts : tuple
+            Values closed over by the integrand, hoisted out by
+            ``jax.closure_convert`` so that they are visible to AD.
+        epsabs, epsrel : jax.Array
+            Absolute and relative error tolerances.
+        kwargs : dict
+            Additional keyword arguments passed to ``rule``.
+
+        Returns
+        -------
+        y : jax.Array
+            The value of the integral.
+        state : dict
+            Full state of the integrator.
+        """
+
+
+class _UnrolledDirectAdjoint(AbstractAdjoint):
+    """Differentiate by unrolling the quadrature loop, with no custom rule.
+
+    This is the original quadax behaviour. It is kept, private and unexported, as the
+    reference implementation that :class:`DirectAdjoint` is tested against. It is
+    correct but expensive: reverse mode must store residuals for every iteration of the
+    loop, including iterations that did no work.
+    """
+
+    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+        """Evaluate the quadrature, differentiating straight through the loop."""
+        vfunc, interval_t = ops.build(interval, args, consts)
+        return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+
+
+class DirectAdjoint(AbstractAdjoint):
+    """Differentiate the quadrature exactly, reusing the converged subdivision.
+
+    Commonly called "discretize then optimize": the quadrature is discretized first, and
+    the derivative is then taken of that discretization.
+
+    This is the default. It is usually the fastest option for forward mode. For a
+    gradient of a scalar-valued integral via ``jax.grad`, :class:`LeibnizAdjoint` can be
+    often several times faster; see :class:`AbstractAdjoint` for the trade-offs.
+
+    It works by running the primal solve recording the final adaptive mesh, and then
+    using the same mesh (with corrections when differentiating the interval itself) to
+    integrate the derivative of the integrand.
+
+    The derivative therefore inherits the subdivision chosen for the integral, and no
+    extra integrand evaluations are spent on error control for it. That is what makes
+    this the cheapest option, and also the reason to reach for a Leibniz adjoint when
+    the derivative needs resolving that the integral did not pay for.
+
+    Parameters
+    ----------
+    checkpoint : bool
+        Whether to recompute the quadrature on each block of sub-intervals during the
+        backward pass rather than storing it. Without it reverse mode keeps the
+        integrand's value at every node of every sub-interval, which dominates its
+        memory and grows with ``max_ninter`` however few sub-intervals are really used;
+        recomputing cuts that by a factor of ten or more and is usually also faster,
+        so it is on by default. Turn it off when the integrand is expensive enough that
+        evaluating it twice costs more than storing the results. No effect in forward
+        mode. Applies to whatever part of a derivative is taken on a fixed subdivision:
+        for :class:`DirectAdjoint` that is the whole of it, for :class:`LeibnizAdjoint`
+        only the derivative with respect to the integration limits, since its derivative
+        with respect to ``args`` comes from a separate solve that stores nothing.
+
+    Methods with no subdivision to reuse (Romberg) are handled the same way in spirit:
+    the number of Richardson levels the solve settled on is frozen instead of a mesh.
+    There the fixed discretization still contains a ``fori_loop`` with dynamic bounds
+    that JAX cannot reverse differentiate, so the derivative is routed through a custom
+    primitive that supplies the two directions explicitly. Both modes work either way.
+    """
+
+    checkpoint: bool = True
+
+    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+        """Evaluate the quadrature and differentiate it on the converged subdivision."""
+        ops = _with_checkpoint(ops, self.checkpoint)
+        if ops.rebuild is None:
+            if ops.frozen_solve is not None:
+                # No subdivision, but a discretization we can freeze (Romberg). Route
+                # through the primitive so that both modes work.
+                return _leibniz(
+                    rule,
+                    interval,
+                    args,
+                    consts,
+                    epsabs,
+                    epsrel,
+                    kwargs,
+                    ops=ops,
+                    freeze=True,
+                )
+            vfunc, interval_t = ops.build(interval, args, consts)
+            return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+        return _direct(rule, interval, args, consts, epsabs, epsrel, kwargs, ops=ops)
+
+
+@eqx.filter_custom_jvp
+def _direct(rule, interval, args, consts, epsabs, epsrel, kwargs, *, ops):
+    vfunc, interval_t = ops.build(interval, args, consts)
+    return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+
+
+@_direct.def_jvp
+def _direct_jvp(primals, tangents, *, ops):
+    y, state = _direct(*primals, ops=ops)
+
+    # Everything the mesh depends on that is *not* smooth (which interval was bisected
+    # at each step, and how the two halves were ordered) is integer valued and was
+    # already decided by the primal solve. Freeze it, then rebuild the mesh as a smooth
+    # function of the limits so that moving a breakpoint moves the mesh with it.
+    dyn, static = eqx.partition(primals, eqx.is_inexact_array)
+    dyn_t = _fill_tangents(dyn, tangents)
+
+    # When the limits are not being differentiated the converged subdivision can be used
+    # as-is. filter_custom_jvp gives a `None` tangent for anything not being
+    # differentiated, so this is known at trace time.
+    interval_perturbed = any(t is not None for t in jax.tree.leaves(tangents[1]))
+
+    def fixed_mesh(dyn_):
+        rule_, interval_, args_, consts_, _, _, kwargs_ = eqx.combine(dyn_, static)
+        vfunc, interval_t = ops.build(interval_, args_, consts_)
+        if interval_perturbed:
+            a_arr, b_arr = ops.rebuild(interval_t, ops.frozen(state))
+        else:
+            a_arr, b_arr = state["a_arr"], state["b_arr"]
+        return ops.on_mesh(rule_, vfunc, a_arr, b_arr, kwargs_)
+
+    y_dot = jax.jvp(fixed_mesh, (dyn,), (dyn_t,))[1]
+    return (y, state), (y_dot, _zero_tangent(state))
+
+
+# ---------------------------------------------------------------------------------
+# Unified Leibniz adjoint.
+#
+# JAX allows a function to carry a custom JVP rule or a custom VJP rule, but not both,
+# which is why the two Leibniz adjoints above are each single-mode. The way around that
+# is to put the *tangent* map in a primitive of its own. The integral itself stays an
+# ordinary custom_jvp (it is not linear in the parameters), but its JVP rule emits this
+# primitive, which is linear in the tangent and carries an explicit transpose rule. JAX
+# then gets forward mode from the JVP and reverse mode by transposing it, and each
+# direction runs the solve it actually needs: a scalar integrand contracted with the
+# tangent going forwards, the vector-valued adjoint integrand coming back.
+_leibniz_p = Primitive("quadax_leibniz_tangent")
+
+
+def _leibniz_unpack(flat, n, treedef, static, frozen_treedef):
+    """Split the operands back into (tangent, primal, frozen discretization)."""
+    tangent = jax.tree.unflatten(treedef, list(flat[:n]))
+    dyn = jax.tree.unflatten(treedef, list(flat[n : 2 * n]))
+    frozen = (
+        None
+        if frozen_treedef is None
+        else jax.tree.unflatten(frozen_treedef, list(flat[2 * n :]))
+    )
+    return tangent, eqx.combine(dyn, static), frozen
+
+
+def _run_solve(ops, rule, integrand, interval_t, epsabs, epsrel, kwargs, frozen):
+    """Adaptive solve, or evaluation on a frozen discretization if there is one."""
+    if frozen is None:
+        return ops.solve(rule, integrand, interval_t, epsabs, epsrel, kwargs)[0]
+    return ops.frozen_solve(rule, integrand, interval_t, frozen, kwargs)
+
+
+def _leibniz_impl(
+    *flat,
+    ops,
+    n,
+    treedef,
+    static,
+    kwargs_items,
+    frozen_treedef,
+    freeze,
+    split,
+    out_sds,
+):
+    """Forward direction: integrate the tangent of the mapped integrand."""
+    dyn_t, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
+    rule, interval, args, consts, epsabs, epsrel = primals
+    kwargs = dict(kwargs_items)
+    dyn = eqx.filter(primals, eqx.is_inexact_array)
+    _, interval_t = ops.build(interval, args, consts)
+
+    def dvfunc(t):
+        def at_t(dyn_):
+            _, interval_, args_, consts_, _, _ = eqx.combine(dyn_, static)
+            vf, _ = ops.build(interval_, args_, consts_)
+            return vf(t)
+
+        return jax.jvp(at_t, (dyn,), (dyn_t,))[1]
+
+    del out_sds
+    # The split below rebuilds the subdivision, which only exists (and is only reverse
+    # differentiable) for the adaptive routines. Romberg has neither a subdivision nor
+    # breakpoints, so there is nothing to split and its level loop cannot be transposed.
+    if freeze or not split:
+        return _run_solve(
+            ops,
+            rule,
+            dvfunc,
+            interval_t,
+            epsabs,
+            epsrel,
+            kwargs,
+            frozen if freeze else None,
+        )
+
+    # Split the tangent. Derivatives with respect to the *limits* have to go through the
+    # subdivision, because a breakpoint sitting on a discontinuity contributes a jump
+    # term that no amount of integrating a derivative can see: in mapped coordinates the
+    # jump moves relative to a fixed mesh, and quadrature of df/dx misses the delta.
+    # Rebuilding the mesh from the limits tracks the breakpoint and recovers it, exactly
+    # as DirectAdjoint does. Everything else keeps the error-controlled solve.
+    dyn_t_rest = (dyn_t[0], jax.tree.map(jnp.zeros_like, dyn_t[1]), *dyn_t[2:])
+
+    def dvfunc_rest(t):
+        def at_t(dyn_):
+            _, interval_, args_, consts_, _, _ = eqx.combine(dyn_, static)
+            vf, _ = ops.build(interval_, args_, consts_)
+            return vf(t)
+
+        return jax.jvp(at_t, (dyn,), (dyn_t_rest,))[1]
+
+    y_dot = ops.solve(rule, dvfunc_rest, interval_t, epsabs, epsrel, kwargs)[0]
+    return (
+        y_dot
+        + jax.jvp(
+            partial(
+                _mesh_quad,
+                ops=ops,
+                rule=rule,
+                args=args,
+                consts=consts,
+                frozen=frozen,
+                kwargs=kwargs,
+            ),
+            (interval,),
+            (dyn_t[1],),
+        )[1]
+    )
+
+
+def _mesh_quad(interval, *, ops, rule, args, consts, frozen, kwargs):
+    """Quadrature on the rebuilt subdivision, as a function of the limits alone."""
+    vfunc, interval_t = ops.build(interval, args, consts)
+    return ops.frozen_solve(rule, vfunc, interval_t, frozen, kwargs)
+
+
+def _leibniz_transpose(
+    ct,
+    *flat,
+    ops,
+    n,
+    treedef,
+    static,
+    kwargs_items,
+    frozen_treedef,
+    freeze,
+    split,
+    out_sds,
+):
+    """Reverse direction: integrate the cotangent of the mapped integrand."""
+    del out_sds
+    _, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
+    rule, interval, args, consts, epsabs, epsrel = primals
+    kwargs = dict(kwargs_items)
+    dyn = eqx.filter(primals, eqx.is_inexact_array)
+    _, interval_t = ops.build(interval, args, consts)
+    _, unravel = ravel_pytree(dyn)
+
+    def adjoint_integrand(t):
+        def at_t(dyn_):
+            _, interval_, args_, consts_, _, _ = eqx.combine(dyn_, static)
+            vf, _ = ops.build(interval_, args_, consts_)
+            return vf(t)
+
+        _, vjp = jax.vjp(at_t, dyn)
+        return ravel_pytree(vjp(ct)[0])[0]
+
+    flat_ct = _run_solve(
+        ops,
+        rule,
+        adjoint_integrand,
+        interval_t,
+        epsabs,
+        epsrel,
+        kwargs,
+        frozen if freeze else None,
+    )
+    ct_tree = unravel(flat_ct)
+    if split:
+        # the limits' cotangent comes from the rebuilt subdivision instead, so that a
+        # breakpoint on a discontinuity picks up its jump term (see _leibniz_impl)
+        ct_iv = jax.vjp(
+            partial(
+                _mesh_quad,
+                ops=ops,
+                rule=rule,
+                args=args,
+                consts=consts,
+                frozen=frozen,
+                kwargs=kwargs,
+            ),
+            interval,
+        )[1](ct)[0]
+        ct_tree = (ct_tree[0], ct_iv, *ct_tree[2:])
+    ct_leaves = jax.tree.flatten(ct_tree)[0]
+    # cotangents for the linear operands, then None for every residual operand
+    n_res = len(flat) - n
+    return tuple(ct_leaves) + (None,) * n_res
+
+
+def _leibniz_batch(args, dims, **params):
+    return jax.vmap(partial(_leibniz_impl, **params), in_axes=tuple(dims))(*args), 0
+
+
+_leibniz_p.def_impl(_leibniz_impl)
+_leibniz_p.def_abstract_eval(
+    lambda *a, out_sds, **kw: jcore.ShapedArray(out_sds.shape, out_sds.dtype)
+)
+mlir.register_lowering(
+    _leibniz_p, mlir.lower_fun(_leibniz_impl, multiple_results=False)
+)
+ad.primitive_transposes[_leibniz_p] = _leibniz_transpose
+batching.primitive_batchers[_leibniz_p] = _leibniz_batch
+
+
+class LeibnizAdjoint(AbstractAdjoint):
+    r"""Differentiate by the Leibniz rule, either mode, with its own error control.
+
+    The derivative is evaluated with its own adaptive solve, so it gets its own error
+    control rather than inheriting the subdivision chosen for the integral -- see
+    :class:`AbstractAdjoint` for when that is worth paying for.
+
+    Both modes come from one object: the integral carries a custom JVP whose tangent is
+    a primitive that is linear in the tangent and supplies an explicit transpose, so JAX
+    takes forward mode from the rule and reverse mode by transposing it.
+
+    Only the direction being asked for is computed. Forward mode integrates the scalar
+    :math:`\partial f/\partial\theta \cdot \dot\theta`; reverse mode integrates the
+    vector-valued :math:`\bar y \cdot \partial f/\partial\theta`. Neither forms the full
+    Jacobian.
+
+    Parameters
+    ----------
+    checkpoint : bool
+        Whether to recompute the quadrature on each block of sub-intervals during the
+        backward pass rather than storing it. Without it reverse mode keeps the
+        integrand's value at every node of every sub-interval, which dominates its
+        memory and grows with ``max_ninter`` however few sub-intervals are really used;
+        recomputing cuts that by a factor of ten or more and is usually also faster,
+        so it is on by default. Turn it off when the integrand is expensive enough that
+        evaluating it twice costs more than storing the results. No effect in forward
+        mode. Applies to whatever part of a derivative is taken on a fixed subdivision:
+        for :class:`DirectAdjoint` that is the whole of it, for :class:`LeibnizAdjoint`
+        only the derivative with respect to the integration limits, since its derivative
+        with respect to ``args`` comes from a separate solve that stores nothing.
+
+    Because each mode picks its own subdivision, forward and reverse results agree to
+    quadrature accuracy rather than exactly.
+
+    Derivatives with respect to the integration limits are taken on the subdivision the
+    primal solve settled on, rather than from the error-controlled solve. In mapped
+    coordinates a moving breakpoint slides a discontinuity across a fixed mesh, and
+    integrating ``df/dx`` cannot represent the resulting delta; rebuilding the mesh from
+    the limits tracks the breakpoint and recovers the jump term. Only the derivative
+    with respect to ``args`` gets its own error control.
+    """
+
+    checkpoint: bool = True
+
+    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+        """Evaluate the quadrature, differentiating it by the Leibniz rule."""
+        ops = _with_checkpoint(ops, self.checkpoint)
+        return _leibniz(
+            rule, interval, args, consts, epsabs, epsrel, kwargs, ops=ops, freeze=False
+        )
+
+
+@eqx.filter_custom_jvp
+def _leibniz(
+    rule, interval, args, consts, epsabs, epsrel, kwargs, *, ops, freeze=False
+):
+    del freeze
+    vfunc, interval_t = ops.build(interval, args, consts)
+    return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+
+
+@_leibniz.def_jvp
+def _leibniz_jvp(primals, tangents, *, ops, freeze=False):
+    y, state = _leibniz(*primals, ops=ops, freeze=freeze)
+    # `kwargs` is a dict, and primitive parameters have to be hashable, so it travels
+    # separately from the pytree that is flattened into the primitive's operands.
+    kwargs = primals[-1]
+    dyn, static = eqx.partition(primals[:-1], eqx.is_inexact_array)
+    dyn_t = _fill_tangents(dyn, tangents[:-1])
+
+    lin_leaves, treedef = jax.tree.flatten(dyn_t)
+    res_leaves = jax.tree.flatten(dyn)[0]
+    # The limits' contribution has to go through the subdivision so that a breakpoint on
+    # a discontinuity picks up its jump term, but that costs an extra fixed-mesh pass
+    # and carries the mesh around. Only do it when the limits are actually being
+    # differentiated, which filter_custom_jvp tells us at trace time by handing us a
+    # `None` tangent for anything that is not. Romberg has no subdivision to split.
+    split = (
+        not freeze
+        and ops.rebuild is not None
+        and any(t is not None for t in jax.tree.leaves(tangents[1]))
+    )
+    if freeze or split:
+        frozen_leaves, frozen_treedef = jax.tree.flatten(
+            jax.lax.stop_gradient(ops.frozen(state))
+        )
+    else:
+        frozen_leaves, frozen_treedef = [], None
+    y_dot = _leibniz_p.bind(
+        *lin_leaves,
+        *res_leaves,
+        *frozen_leaves,
+        ops=ops,
+        n=len(lin_leaves),
+        treedef=treedef,
+        static=static,
+        kwargs_items=tuple(sorted(kwargs.items())),
+        frozen_treedef=frozen_treedef,
+        freeze=freeze,
+        split=split,
+        out_sds=jax.ShapeDtypeStruct(jnp.shape(y), jnp.result_type(y)),
+    )
+    return (y, state), (y_dot, _zero_tangent(state))

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax._src import core as jcore
 from jax.extend.core import Primitive
 from jax.flatten_util import ravel_pytree
@@ -101,13 +102,20 @@ def _with_checkpoint(ops, checkpoint):
 
 
 def _zero_tangent(tree):
-    """Zero tangent for a pytree, using None for non-inexact leaves."""
+    """Zero tangent for a pytree, materialized rather than symbolic.
+
+    Nothing in the integrator state is differentiable, so every leaf gets an explicit
+    zero: an ordinary zeros array for the inexact leaves, and a ``float0`` array (the
+    tangent type of a non-inexact primal, and zero-sized) for the integer and boolean
+    bookkeeping. Returning ``None`` for the latter would be more natural but this causes
+    problems with jax 0.7.0 and 0.7.1.
+    """
 
     def z(x):
         x = jnp.asarray(x)
         if jnp.issubdtype(x.dtype, jnp.inexact):
             return jnp.zeros_like(x)
-        return None
+        return np.zeros(x.shape, dtype=jax.dtypes.float0)
 
     return jax.tree.map(z, tree)
 

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -309,16 +309,16 @@ def _direct_jvp(primals, tangents, *, ops):
 
 
 # ---------------------------------------------------------------------------------
-# Unified Leibniz adjoint.
+# Leibniz adjoint.
 #
 # JAX allows a function to carry a custom JVP rule or a custom VJP rule, but not both,
-# which is why the two Leibniz adjoints above are each single-mode. The way around that
-# is to put the *tangent* map in a primitive of its own. The integral itself stays an
-# ordinary custom_jvp (it is not linear in the parameters), but its JVP rule emits this
-# primitive, which is linear in the tangent and carries an explicit transpose rule. JAX
-# then gets forward mode from the JVP and reverse mode by transposing it, and each
-# direction runs the solve it actually needs: a scalar integrand contracted with the
-# tangent going forwards, the vector-valued adjoint integrand coming back.
+# The way around that is to put the *tangent* map in a primitive of its own. The
+# integral itself stays an ordinary custom_jvp (it is not linear in the parameters), but
+# its JVP rule emits this primitive, which is linear in the tangent and carries an
+# explicit transpose rule. JAX then gets forward mode from the JVP and reverse mode by
+# transposing it, and each direction runs the solve it actually needs: a scalar
+# integrand contracted with the tangent going forwards, the vector-valued adjoint
+# integrand coming back.
 _leibniz_p = Primitive("quadax_leibniz_tangent")
 
 

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -169,9 +169,20 @@ class NestedRule(AbstractQuadratureRule):
             uflow = jnp.finfo(f.dtype).tiny
             eps = jnp.finfo(f.dtype).eps
             abserr = jnp.abs(result_kronrod - result_gauss)
+            # double where trick to avoid nans when ratio would be zero or inf
+            # The scaling is only defined when both quantities are nonzero. The ratio
+            # must also be substituted, not just masked afterwards: ``x ** 1.5`` has an
+            # infinite second derivative at ``x == 0``, so differentiating the
+            # unselected branch twice yields ``inf * 0 == nan``, which ``where``
+            # then propagates.
+            # ``abserr`` is exactly zero whenever the two rules agree to the last bit,
+            # which a smooth enough integrand does reach.
+            scalable = (integral_mmn != 0.0) & (abserr != 0.0)
+            mmn_safe = jnp.where(scalable, integral_mmn, 1.0)
+            ratio = jnp.where(scalable, 200.0 * abserr / mmn_safe, 1.0)
             abserr = jnp.where(
-                (integral_mmn != 0.0) & (abserr != 0.0),
-                integral_mmn * jnp.minimum(1.0, (200.0 * abserr / integral_mmn) ** 1.5),
+                scalable,
+                integral_mmn * jnp.minimum(1.0, ratio**1.5),
                 abserr,
             )
             abserr = jnp.where(

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -60,6 +60,39 @@ class AbstractQuadratureRule(eqx.Module):
 
         """
 
+    def _apply(
+        self,
+        fun: Callable[..., jax.Array],
+        a: float,
+        b: float,
+        args: tuple[Any, ...],
+    ) -> jax.Array:
+        """Integrate ``fun(x, *args)`` from a to b, without an error estimate.
+
+        Internal: used by the adjoints where many sub-intervals are evaluated at once
+        and only the values are wanted. Users writing a custom rule do not need to
+        touch this; the default below is correct, and subclasses only override it when
+        they can compute the value more cheaply than by discarding the error estimate
+        from :meth:`integrate`.
+
+        Parameters
+        ----------
+        fun : callable
+            Function to integrate, should have a signature of the form
+            ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
+        a, b : float
+            Lower and upper limits of integration. Must be finite.
+        args : tuple, optional
+            Extra arguments passed to fun.
+
+        Returns
+        -------
+        y : float, Array
+            Estimate of the integral of fun from a to b.
+
+        """
+        return self.integrate(fun, a, b, args)[0]
+
     def norm(self, x: jax.Array) -> jax.Array:
         """Norm to use for measuring error for vector valued integrands."""
         return jnp.linalg.norm(jnp.asarray(x).flatten(), ord=jnp.inf)
@@ -149,6 +182,25 @@ class NestedRule(AbstractQuadratureRule):
             return result, self.norm(abserr), integral_abs, integral_mmn
 
         return jax.lax.cond(a == b, truefun, falsefun)
+
+    @eqx.filter_jit
+    def _apply(
+        self,
+        fun: Callable[..., jax.Array],
+        a: float,
+        b: float,
+        args: tuple[Any, ...],
+    ) -> jax.Array:
+        """Integrate a function from a to b, without an error estimate.
+
+        Only the high order rule is summed, skipping the low order rule and the two
+        auxiliary sums that ``integrate`` needs for its error estimate.
+        """
+        vfun = wrap_func(fun, args)
+        halflength = (b - a) / 2
+        center = (b + a) / 2
+        f: jax.Array = vfun(center + halflength * self._xh)
+        return _dot(self._wh, f) * halflength
 
     def norm(self, x: jax.Array) -> jax.Array:
         """Norm to use for measuring error for vector valued integrands."""

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -8,6 +8,14 @@ import jax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
 
+from .adjoint import (
+    AbstractAdjoint,
+    DirectAdjoint,
+    QuadratureOps,
+    _ConvertedFunction,
+    build_integrand,
+    closure_convert,
+)
 from .utils import (
     QuadratureInfo,
     _get_eps,
@@ -30,6 +38,7 @@ def romberg(
     epsrel: ArrayLike | None = None,
     divmax: int = 20,
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
 ):
     """Romberg integration of a callable function or method.
 
@@ -64,6 +73,13 @@ def romberg(
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which gives the exact derivative of the discretized problem in either mode, and
+        is usually the fastest option. ``LeibnizAdjoint`` is slower but gives the
+        derivative its own error control (ie, can better approximate the true
+        continuous derivative), and in reverse mode uses much less memory; see
+        ``AbstractAdjoint`` for when that is worth paying for.
 
     Returns
     -------
@@ -89,10 +105,12 @@ def romberg(
     sequential and does not vectorize integrand evaluations, so may not be the most
     efficient on GPU/TPU.
 
-    Also, it is currently only forward mode differentiable.
-
     """
     interval = jnp.atleast_1d(jnp.asarray(interval))
+    if not jnp.issubdtype(interval.dtype, jnp.inexact):
+        # integration limits must be inexact: they are differentiated with respect to,
+        # and integer leaves would otherwise be treated as static metadata
+        interval = interval.astype(jnp.result_type(float))
     errorif(
         len(interval) != 2,
         NotImplementedError,
@@ -102,14 +120,66 @@ def romberg(
         epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
     if epsrel is None:
         epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
+    epsabs = jnp.asarray(epsabs)
+    epsrel = jnp.asarray(epsrel)
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
         _norm: Callable[[jax.Array], jax.Array] = partial(_pnorm, p=norm)
 
-    # map a, b -> [-1, 1]
-    fun, interval = map_interval(fun, interval)
-    vfunc = wrap_func(fun, args)
+    return _romberg(
+        fun,
+        interval,
+        args,
+        full_output,
+        epsabs,
+        epsrel,
+        divmax,
+        _norm,
+        adjoint,
+        build_integrand,
+    )
+
+
+def _romberg(
+    fun, interval, args, full_output, epsabs, epsrel, divmax, _norm, adjoint, build
+):
+    """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
+    # Closure conversion has to happen on the user's function, before any wrapping:
+    # once a transformed integrand crosses a filter_jit boundary its leaves become
+    # tracers that closure_convert cannot hoist.
+    f_conv, consts = closure_convert(fun, args)
+    # Romberg has no subdivision to reuse, so `rebuild`/`on_mesh` are left unset and
+    # DirectAdjoint falls back to differentiating through the loop.
+    ops = QuadratureOps(
+        build=partial(build, f_conv=f_conv),
+        solve=partial(_romberg_solve, divmax=divmax, _norm=_norm),
+        # Romberg has no subdivision to reuse, but it does settle on a number of
+        # Richardson levels. Freezing that makes the result a fixed linear functional of
+        # the integrand, which is what DirectAdjoint needs to differentiate in either
+        # direction. It has to go through a custom primitive rather than being
+        # differentiated directly, because evaluating it still involves a fori_loop with
+        # dynamic bounds that JAX cannot reverse differentiate.
+        frozen=lambda state: state["n"],
+        frozen_solve=partial(_romberg_levels, divmax=divmax),
+    )
+    y, state = adjoint.quadrature(ops, None, interval, args, consts, epsabs, epsrel, {})
+    info = state["table"] if full_output else None
+    out = QuadratureInfo(state["err_sum"], state["neval"], state["status"], info)
+    return y, out
+
+
+def _build_tanhsinh(interval, args, consts, *, f_conv):
+    """Build the integrand for ``rombergts``: tanh-sinh, then map to the reference."""
+    fun = _ConvertedFunction(f_conv, args, consts)
+    fun_t, interval_t = tanhsinh_transform(fun, interval)
+    fun_m, interval_m = map_interval(fun_t, interval_t)
+    return wrap_func(fun_m, ()), interval_m
+
+
+def _romberg_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, divmax, _norm):
+    """Run the Romberg/Richardson extrapolation loop."""
+    del rule, kwargs
     a, b = interval
     f = jax.eval_shape(vfunc, (a + b) / 2)
 
@@ -156,9 +226,46 @@ def romberg(
 
     y = result[n - 1, n - 1]
     status = 2 * (err > jnp.maximum(epsabs, epsrel * _norm(y)))
-    info = result if full_output else None
-    out = QuadratureInfo(err, neval, status, info)
-    return y, out
+    state = {
+        "table": result,
+        "err_sum": err,
+        "neval": neval,
+        "status": status,
+        "n": n,  # Richardson levels used; frozen by DirectAdjoint
+    }
+    return y, state
+
+
+def _romberg_levels(rule, vfunc, interval, n, kwargs, *, divmax):
+    """Evaluate the Richardson table at a fixed number of levels.
+
+    With ``n`` fixed this is a fixed linear combination of the integrand at fixed nodes,
+    so its forward and reverse derivatives are exact transposes of one another. Mirrors
+    the loop in ``_romberg_solve`` exactly so the two agree.
+    """
+    del rule, kwargs
+    a, b = interval[0], interval[-1]
+    f = jax.eval_shape(vfunc, (a + b) / 2)
+    result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
+    result = result.at[0, 0].set(vfunc(a) + vfunc(b))
+
+    def nloop(k, result):
+        h = (b - a) / 2**k
+
+        def sloop(i, s):
+            return s + vfunc(a + h * (2 * i - 1))
+
+        s = jax.lax.fori_loop(1, (2**k) // 2 + 1, sloop, jnp.zeros(f.shape, f.dtype))
+        result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
+
+        def mloop(m, result):
+            temp = 1 / (4.0**m - 1.0) * (result[k, m - 1] - result[k - 1, m - 1])
+            return result.at[k, m].set(result[k, m - 1] + temp)
+
+        return jax.lax.fori_loop(1, k + 1, mloop, result)
+
+    result = jax.lax.fori_loop(1, n, nloop, result)
+    return result[n - 1, n - 1]
 
 
 @eqx.filter_jit
@@ -171,6 +278,7 @@ def rombergts(
     epsrel: ArrayLike | None = None,
     divmax: int = 20,
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
+    adjoint: AbstractAdjoint = DirectAdjoint(),
 ):
     """Romberg integration with tanh-sinh (aka double exponential) transformation.
 
@@ -205,6 +313,13 @@ def rombergts(
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    adjoint : AbstractAdjoint, optional
+        How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
+        which gives the exact derivative of the discretized problem in either mode, and
+        is usually the fastest option. ``LeibnizAdjoint`` is slower but gives the
+        derivative its own error control (ie, can better approximate the true
+        continuous derivative), and in reverse mode uses much less memory; see
+        ``AbstractAdjoint`` for when that is worth paying for.
 
 
     Returns
@@ -231,8 +346,37 @@ def rombergts(
     sequential and does not vectorize integrand evaluations, so may not be the most
     efficient on GPU/TPU.
 
-    Also, it is currently only forward mode differentiable.
-
     """
-    fun, interval = tanhsinh_transform(fun, interval)
-    return romberg(fun, interval, args, full_output, epsabs, epsrel, divmax, norm)
+    interval = jnp.atleast_1d(jnp.asarray(interval))
+    if not jnp.issubdtype(interval.dtype, jnp.inexact):
+        # integration limits must be inexact: they are differentiated with respect to,
+        # and integer leaves would otherwise be treated as static metadata
+        interval = interval.astype(jnp.result_type(float))
+    errorif(
+        len(interval) != 2,
+        NotImplementedError,
+        "tanh-sinh transformation with breakpoints not supported",
+    )
+    if epsabs is None:
+        epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
+    if epsrel is None:
+        epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
+    epsabs = jnp.asarray(epsabs)
+    epsrel = jnp.asarray(epsrel)
+    if callable(norm):
+        _norm: Callable[[jax.Array], jax.Array] = norm
+    else:
+        _norm: Callable[[jax.Array], jax.Array] = partial(_pnorm, p=norm)
+
+    return _romberg(
+        fun,
+        interval,
+        args,
+        full_output,
+        epsabs,
+        epsrel,
+        divmax,
+        _norm,
+        adjoint,
+        _build_tanhsinh,
+    )

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -75,11 +75,12 @@ def romberg(
         should be callable.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which gives the exact derivative of the discretized problem in either mode, and
-        is usually the fastest option. ``LeibnizAdjoint`` is slower but gives the
-        derivative its own error control (ie, can better approximate the true
-        continuous derivative), and in reverse mode uses much less memory; see
-        ``AbstractAdjoint`` for when that is worth paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
 
     Returns
     -------
@@ -315,11 +316,12 @@ def rombergts(
         should be callable.
     adjoint : AbstractAdjoint, optional
         How to compute derivatives of the quadrature. Default is ``DirectAdjoint()``,
-        which gives the exact derivative of the discretized problem in either mode, and
-        is usually the fastest option. ``LeibnizAdjoint`` is slower but gives the
-        derivative its own error control (ie, can better approximate the true
-        continuous derivative), and in reverse mode uses much less memory; see
-        ``AbstractAdjoint`` for when that is worth paying for.
+        which is gives the exact derivative of the discretized problem, and is the
+        cheaper option for a cheap integrand. ``LeibnizAdjoint`` gives the derivative
+        its own error control (ie, can better approximate the true continuous
+        derivative), and is faster when the integrand is expensive or ``max_ninter``
+        is generous; see the Adjoints section of the API documentation for when that
+        is worth paying for.
 
 
     Returns

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -7,6 +7,7 @@ from typing import Any, NamedTuple
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from equinox.internal import unvmap_any
 from jax.typing import ArrayLike
 
 
@@ -303,12 +304,33 @@ class QuadratureInfo(NamedTuple):
 
 
 def bounded_while_loop(condfun, bodyfun, init_val, bound):
-    """While loop for bounded number of iterations, implemented using cond and scan."""
+    """While loop for bounded number of iterations, implemented using cond and scan.
+
+    Implemented with ``scan`` rather than ``lax.while_loop`` so that it can be reverse
+    mode differentiated.
+
+    Each iteration is gated twice. The outer gate is
+    ``unvmap_any(condfun(state))``, a scalar, so it stays a real branch under ``vmap``
+    and the loop stops doing work once *every* batch element has converged. Without it
+    the raw predicate is per-element, the branch degrades to a ``select``, and the body
+    runs for all ``bound`` iterations however few elements still need it. The inner gate
+    is the raw predicate, which unbatched is a second cheap branch and batched is the
+    per-element select that leaves already-converged elements untouched. Results are
+    unchanged either way.
+    """
     # could do some fancy stuff with checkpointing here like in equinox but the loops
     # in quadax usually only do ~100 iterations max so probably not worth it.
 
     def scanfun(state, *args):
-        return jax.lax.cond(condfun(state), bodyfun, lambda x: x, state), None
+        keep = condfun(state)
+
+        def stepfun(state):
+            # Inner branch on the raw predicate. Unbatched this is a second real branch
+            # and costs almost nothing; batched it becomes a select, which is the
+            # per-element masking that keeps already-converged elements untouched.
+            return jax.lax.cond(keep, bodyfun, lambda x: x, state)
+
+        return jax.lax.cond(unvmap_any(keep), stepfun, lambda x: x, state), None
 
     return jax.lax.scan(scanfun, init_val, None, bound)[0]
 

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -747,3 +747,41 @@ def test_escaped_tracers():
 
     with jax.checking_leaks():
         jax.block_until_ready(integral_rombergts([0.0, 1.0]))
+
+
+@pytest.mark.parametrize("quad", [quadgk, quadcc, quadts])
+@pytest.mark.parametrize("max_ninter", [8, 12, 20, 33])
+def test_subdivision_tiles_the_domain(quad, max_ninter):
+    """The sub-intervals must tile the whole domain, even when max_ninter is hit.
+
+    Regression test: the new half of a bisection used to be written at the interval
+    count *after* incrementing it, which skipped a slot and, on the last iteration,
+    scattered out of bounds. That silently dropped one sub-interval from the mesh, so
+    part of the domain was never integrated and ``ninter`` over-reported by one.
+    """
+    # needs far more subdivisions than allowed, so max_ninter is always reached
+    fun = lambda t: 1.0 / jnp.sqrt(jnp.abs(t - 0.3) + 1e-9)
+    y, info = quad(fun, [0.0, 1.0], (), True, max_ninter=max_ninter)
+
+    a_arr, b_arr = info.info["a_arr"], info.info["b_arr"]
+    ninter = int(info.info["ninter"])
+    # the mapped reference domain is [-1, 1], so the widths must sum to exactly 2
+    np.testing.assert_allclose(float(jnp.sum(b_arr - a_arr)), 2.0, rtol=0, atol=1e-14)
+    # and every counted interval must actually be present
+    assert int(jnp.sum(jnp.asarray(info.info["r_arr"]) != 0)) == ninter
+    assert ninter <= max_ninter
+
+
+@pytest.mark.parametrize("quad", [quadgk, quadcc, quadts])
+def test_truncated_result_is_still_a_partition(quad):
+    """Sub-intervals must be disjoint and contiguous when max_ninter is reached."""
+    fun = lambda t: 1.0 / jnp.sqrt(jnp.abs(t - 0.3) + 1e-9)
+    _, info = quad(fun, [0.0, 1.0], (), True, max_ninter=16)
+    n = int(info.info["ninter"])
+    a = np.asarray(info.info["a_arr"])[:n]
+    b = np.asarray(info.info["b_arr"])[:n]
+    order = np.argsort(a)
+    a, b = a[order], b[order]
+    np.testing.assert_allclose(a[0], -1.0, atol=1e-14)
+    np.testing.assert_allclose(b[-1], 1.0, atol=1e-14)
+    np.testing.assert_allclose(a[1:], b[:-1], atol=1e-14)

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -30,6 +30,13 @@ adaptive_methods = [quadgk, quadcc, quadts]
 romberg_methods = [romberg, rombergts]
 all_methods = adaptive_methods + romberg_methods
 
+# The three adaptive routines differ only in the local rule applied on each
+# sub-interval; the subdivision loop and the adjoints wrapped around it are the same
+# code, so tests of that machinery run through one of them rather than all three. The
+# checks on the derivative itself keep the full list, since there each rule's own
+# accuracy is part of what is under test.
+machinery_methods = [quadgk]
+
 # problems exercising the paths that differ: plain, interior breakpoints, an infinite
 # limit, and a vector valued integrand.
 example_problems = [
@@ -155,28 +162,28 @@ class TestDirectAdjointEquivalence:
         new = transform(make(DirectAdjoint()))(x)
         return np.asarray(jax.tree.leaves(old)[0]), np.asarray(jax.tree.leaves(new)[0])
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", range(len(example_problems)))
     def test_jacfwd_wrt_args(self, quad, i):
         """Forward mode w.r.t. args matches unrolled loop."""
         old, new = self._jacs(quad, example_problems[i], False, jax.jacfwd)
         np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", range(len(example_problems)))
     def test_jacfwd_wrt_interval(self, quad, i):
         """Forward mode w.r.t. limits and breakpoints matches unrolled loop."""
         old, new = self._jacs(quad, example_problems[i], True, jax.jacfwd)
         np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", range(len(example_problems)))
     def test_jacrev_wrt_args(self, quad, i):
         """Reverse mode w.r.t. args matches unrolled loop."""
         old, new = self._jacs(quad, example_problems[i], False, jax.jacrev)
         np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", range(len(example_problems)))
     def test_jacrev_matches_own_jacfwd(self, quad, i):
         """Direct adjoint's forward and reverse modes agree with each other."""
@@ -215,7 +222,7 @@ class TestBreakpointBoundaryTerm:
             np.asarray(transform(f)(self.interval)), self.expected, atol=1e-12
         )
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     def test_matches_unrolled(self, quad):
         """And agrees with differentiating through the loop."""
         mk = lambda adj: lambda v: quad(self.fun, v, self.args, adjoint=adj)[0]
@@ -230,7 +237,7 @@ class TestBreakpointBoundaryTerm:
 class TestLeibnizAdjoints:
     """The Leibniz adjoints give the derivative its own error control."""
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", SMOOTH_PROBLEMS)
     def test_forward_matches_finite_difference(self, quad, i):
         """Leibniz adjoint agrees with finite differences in forward mode."""
@@ -244,7 +251,7 @@ class TestLeibnizAdjoints:
             rtol=1e-4,
         )
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("i", SMOOTH_PROBLEMS)
     def test_reverse_matches_finite_difference(self, quad, i):
         """Leibniz adjoint agrees with finite differences in reverse mode."""
@@ -258,7 +265,7 @@ class TestLeibnizAdjoints:
             rtol=1e-4,
         )
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     def test_leibniz_agrees_with_direct(self, quad):
         """Leibniz agrees with DirectAdjoint on a well resolved problem, both modes."""
         prob = example_problems[0]
@@ -441,7 +448,7 @@ class TestUnifiedLeibnizAdjoint:
         f = lambda c: quad(self.fun, self.interval, (c,), adjoint=DirectAdjoint())[0]
         return np.asarray(jax.jacfwd(f)(self.args))
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize(
         "transform", [jax.jacfwd, jax.jacrev, jax.grad, lambda f: jax.jit(jax.grad(f))]
     )
@@ -452,7 +459,7 @@ class TestUnifiedLeibnizAdjoint:
             np.asarray(transform(f)(self.args)), self._ref(quad), rtol=1e-8
         )
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     def test_jvp_matches_a_directional_derivative(self, quad):
         """Forward mode contracts with the tangent rather than forming the Jacobian."""
         f = lambda c: quad(self.fun, self.interval, (c,), adjoint=LeibnizAdjoint())[0]
@@ -463,7 +470,7 @@ class TestUnifiedLeibnizAdjoint:
             rtol=1e-8,
         )
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev])
     def test_wrt_interval(self, quad, transform):
         """Derivatives with respect to the limits work in both modes."""

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -506,6 +506,59 @@ class TestUnifiedLeibnizAdjoint:
         )
         assert np.asarray(jax.hessian(f)(self.args)).shape == (3, 3)
 
+    @pytest.mark.parametrize("quad", machinery_methods)
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev, jax.grad])
+    @pytest.mark.parametrize("wrt_interval", [False, True])
+    def test_python_float_tolerances(self, quad, transform, wrt_interval):
+        """A tolerance given as a python float must differentiate like any other.
+
+        Every other test here leaves the tolerances at their default, which the solver
+        turns into arrays. A concrete float instead reaches the primitive as a jaxpr
+        literal, and reverse mode used to lose that operand when the transpose rule
+        rebuilt its cotangent tree by filtering values for inexact arrays -- returning
+        one cotangent fewer than the primitive had linear operands.
+        """
+        if wrt_interval and transform is jax.grad:
+            pytest.skip("grad needs a scalar output; jacrev covers the same path")
+        kwargs = {"epsabs": 1e-8, "epsrel": 1e-8}
+        if wrt_interval:
+            f = lambda v: quad(
+                self.fun, v, (self.args,), adjoint=LeibnizAdjoint(), **kwargs
+            )[0]  # noqa: E501
+            target = self.interval
+        else:
+            f = lambda c: quad(
+                self.fun, self.interval, (c,), adjoint=LeibnizAdjoint(), **kwargs
+            )[0]  # noqa: E501
+            target = self.args
+        np.testing.assert_allclose(
+            np.asarray(transform(f)(target)),
+            self._ref(quad, wrt_interval=wrt_interval),
+            rtol=1e-7,
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_python_float_tolerances_romberg_direct(self, quad):
+        """Romberg reaches the same primitive under ``DirectAdjoint``.
+
+        It has no subdivision to reuse, so ``DirectAdjoint`` freezes the level count and
+        routes through ``_leibniz`` to get a transposable rule -- which means the
+        literal tolerance bug reached ``DirectAdjoint`` too, by this path only.
+        """
+        f = lambda c: quad(  # noqa: E731
+            self.fun,
+            self.interval,
+            (c,),
+            adjoint=DirectAdjoint(),
+            epsabs=1e-8,
+            epsrel=1e-8,
+        )[0]
+        np.testing.assert_allclose(
+            np.asarray(jax.grad(f)(self.args)),
+            np.asarray(jax.jacfwd(f)(self.args)),
+            rtol=1e-7,
+        )
+
 
 @pytest.mark.parametrize("quad", all_methods)
 @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -1,187 +1,531 @@
-"""Tests for custom jvp for adaptive quadrature routines."""
+"""Tests for differentiating quadrature, and for the adjoints that control how.
+
+Covers both halves of the same subject: that the derivatives are *correct* (checked
+against finite differences and, where available, analytic values), and that each
+:class:`~quadax.AbstractAdjoint` implementation computes them equivalently while
+surviving the usual JAX transforms.
+"""
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jax import config
 
-from quadax import quadcc, quadgk, quadts, romberg, rombergts
+from quadax import (
+    DirectAdjoint,
+    LeibnizAdjoint,
+    quadcc,
+    quadgk,
+    quadts,
+    romberg,
+    rombergts,
+)
+from quadax.adjoint import _UnrolledDirectAdjoint
 
 config.update("jax_enable_x64", True)
 
 
-rng = np.random.default_rng(0)
-A0 = 0.5 - rng.random(3)
+adaptive_methods = [quadgk, quadcc, quadts]
+romberg_methods = [romberg, rombergts]
+all_methods = adaptive_methods + romberg_methods
 
-
+# problems exercising the paths that differ: plain, interior breakpoints, an infinite
+# limit, and a vector valued integrand.
 example_problems = [
-    # problem 0
     {
         "fun": lambda t, c: jnp.log(c * t).squeeze(),
-        "interval": [1, 3],
+        "interval": [1.0, 3.0],
         "args": (np.array([3.12]),),
     },
-    # problem 1
+    {
+        "fun": lambda t, c: jnp.log(c * t).squeeze(),
+        "interval": [1.0, 1.7, 2.2, 3.0],
+        "args": (np.array([3.12]),),
+    },
     {
         "fun": lambda t, m_s: jnp.exp(-((t - m_s[0]) ** 2) / m_s[1] ** 2).squeeze(),
-        "interval": [-2, 3],
+        "interval": [-2.0, 3.0],
         "args": (np.array([1.23, 0.67]),),
     },
+    {
+        "fun": lambda t, m_s: jnp.exp(-((t - m_s[0]) ** 2) / m_s[1] ** 2).squeeze(),
+        "interval": [-jnp.inf, jnp.inf],
+        "args": (np.array([1.23, 0.67]),),
+    },
+    {  # vector valued
+        "fun": lambda t, c: jnp.array([jnp.sin(c[0] * t), jnp.cos(c[1] * t)]).squeeze(),
+        "interval": [0.0, 2.0],
+        "args": (np.array([1.1, 0.7]),),
+    },
 ]
+
+# the two problems with finite limits and no breakpoints, used where a finite difference
+# reference is wanted and the quadrature must be well converged
+SMOOTH_PROBLEMS = [0, 2]
+
+# DirectAdjoint and UnrolledDirectAdjoint should agree to ~1 ULP
+ULP_RTOL = 1e-13
+ULP_ATOL = 1e-15
 
 
 def finite_difference(f, x, eps=1e-8):
     """Util for 2nd order centered finite differences."""
     x0 = np.atleast_1d(x).squeeze()
     f0 = f((x0,))
-    m = f0.size
-    n = x0.size
-    J = np.zeros((m, n))
+    J = np.zeros((np.atleast_1d(f0).size, x0.size))
     h = np.maximum(1.0, np.abs(x0)) * eps
     h_vecs = np.diag(np.atleast_1d(h))
-    for i in range(n):
-        x1 = x0 - h_vecs[i]
-        x2 = x0 + h_vecs[i]
-        if x0.ndim:
-            dx = x2[i] - x1[i]
-        else:
-            dx = x2 - x1
-        f1 = f((x1,))
-        f2 = f((x2,))
-        df = f2 - f1
-        dfdx = df / dx
-        J[:, i] = dfdx.flatten()
-    if m == 1:
-        J = np.ravel(J)
-    return J
+    for i in range(x0.size):
+        x1, x2 = x0 - h_vecs[i], x0 + h_vecs[i]
+        dx = (x2[i] - x1[i]) if x0.ndim else (x2 - x1)
+        J[:, i] = ((f((x2,)) - f((x1,))) / dx).flatten()
+    return np.ravel(J) if J.shape[0] == 1 else J
 
 
-class TestQuadGKJac:
-    """Tests for derivatives of quadgk."""
+@pytest.mark.parametrize("quad", all_methods)
+@pytest.mark.parametrize("i", SMOOTH_PROBLEMS)
+class TestDefaultAdjointAgainstFiniteDifference:
+    """Every method's default adjoint must agree with finite differences.
 
-    def _base(self, i, tol, **kwargs):
+    This is the end to end check on the derivative itself, independent of which adjoint
+    is used internally, so it is deliberately parametrized over all five entry points
+    rather than duplicated per method.
+    """
 
+    def _integrate(self, quad, i):
         prob = example_problems[i]
+        return lambda args: quad(prob["fun"], prob["interval"], args)[0]
 
-        def integrate(args):
-            y, err = quadgk(prob["fun"], prob["interval"], args, **kwargs)
-            return y
+    def test_jacfwd(self, quad, i):
+        """Forward mode matches finite differences."""
+        f = self._integrate(quad, i)
+        np.testing.assert_allclose(
+            finite_difference(f, example_problems[i]["args"]),
+            np.asarray(jax.jacfwd(f)(example_problems[i]["args"])[0]),
+            atol=1e-4,
+            rtol=1e-4,
+        )
 
-        jacfd = finite_difference(integrate, prob["args"])
-        jacadf = jax.jacfwd(integrate)(prob["args"])[0]
-        jacadr = jax.jacrev(integrate)(prob["args"])[0]
-        np.testing.assert_allclose(jacfd, jacadf, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacfd, jacadr, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacadr, jacadf, atol=1e-14, rtol=1e-14)
+    def test_jacrev(self, quad, i):
+        """Reverse mode matches finite differences."""
+        f = self._integrate(quad, i)
+        np.testing.assert_allclose(
+            finite_difference(f, example_problems[i]["args"]),
+            np.asarray(jax.jacrev(f)(example_problems[i]["args"])[0]),
+            atol=1e-4,
+            rtol=1e-4,
+        )
 
-    def test_prob0(self):
-        """Test for derivative of integral of log."""
-        self._base(0, 1e-4)
+    def test_modes_agree(self, quad, i):
+        """Forward and reverse agree far more tightly than either matches FD.
 
-    def test_prob1(self):
-        """Test for derivative of integral of gaussian."""
-        self._base(1, 1e-4)
+        They are transposes of the same linear functional, so they should agree to
+        rounding rather than merely to the accuracy of the quadrature.
+        """
+        f = self._integrate(quad, i)
+        args = example_problems[i]["args"]
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(f)(args)[0]),
+            np.asarray(jax.jacrev(f)(args)[0]),
+            rtol=1e-14,
+            atol=1e-14,
+        )
 
 
-class TestQuadCCJac:
-    """Tests for derivatives of quadcc."""
+class TestDirectAdjointEquivalence:
+    """DirectAdjoint must reproduce differentiating through the loop.
 
-    def _base(self, i, tol, **kwargs):
+    This is the safety gate for reimplementing the default adjoint: the old
+    implementation is kept privately as ``_UnrolledDirectAdjoint`` purely so that the
+    new one can be compared against it.
+    """
 
+    def _jacs(self, quad, prob, wrt_interval, transform):
+        interval = jnp.asarray(prob["interval"])
+        args = prob["args"]
+
+        def make(adjoint):
+            if wrt_interval:
+                return lambda v: quad(prob["fun"], v, args, adjoint=adjoint)[0]
+            return lambda a: quad(prob["fun"], interval, a, adjoint=adjoint)[0]
+
+        x = interval if wrt_interval else args
+        old = transform(make(_UnrolledDirectAdjoint()))(x)
+        new = transform(make(DirectAdjoint()))(x)
+        return np.asarray(jax.tree.leaves(old)[0]), np.asarray(jax.tree.leaves(new)[0])
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_jacfwd_wrt_args(self, quad, i):
+        """Forward mode w.r.t. args matches unrolled loop."""
+        old, new = self._jacs(quad, example_problems[i], False, jax.jacfwd)
+        np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_jacfwd_wrt_interval(self, quad, i):
+        """Forward mode w.r.t. limits and breakpoints matches unrolled loop."""
+        old, new = self._jacs(quad, example_problems[i], True, jax.jacfwd)
+        np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_jacrev_wrt_args(self, quad, i):
+        """Reverse mode w.r.t. args matches unrolled loop."""
+        old, new = self._jacs(quad, example_problems[i], False, jax.jacrev)
+        np.testing.assert_allclose(old, new, rtol=ULP_RTOL, atol=ULP_ATOL)
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_jacrev_matches_own_jacfwd(self, quad, i):
+        """Direct adjoint's forward and reverse modes agree with each other."""
         prob = example_problems[i]
-
-        def integrate(args):
-            y, err = quadcc(prob["fun"], prob["interval"], args, **kwargs)
-            return y
-
-        jacfd = finite_difference(integrate, prob["args"])
-        jacadf = jax.jacfwd(integrate)(prob["args"])[0]
-        jacadr = jax.jacrev(integrate)(prob["args"])[0]
-        np.testing.assert_allclose(jacfd, jacadf, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacfd, jacadr, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacadr, jacadf, atol=1e-14, rtol=1e-14)
-
-    def test_prob0(self):
-        """Test for derivative of integral of log."""
-        self._base(0, 1e-4)
-
-    def test_prob1(self):
-        """Test for derivative of integral of gaussian."""
-        self._base(1, 1e-4)
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quad(prob["fun"], interval, a, adjoint=DirectAdjoint())[0]
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(f)(prob["args"])[0]),
+            np.asarray(jax.jacrev(f)(prob["args"])[0]),
+            rtol=ULP_RTOL,
+            atol=ULP_ATOL,
+        )
 
 
-class TestQuadTSJac:
-    """Tests for derivatives of quadts."""
+class TestBreakpointBoundaryTerm:
+    """Moving a breakpoint that sits on a jump must produce the boundary term.
 
-    def _base(self, i, tol, **kwargs):
+    Simply freezing the converged subdivision loses this: in mapped coordinates a frozen
+    mesh edge does not move with the breakpoint, so it cannot see the jump slide across
+    it, and the derivative comes out as ``[-3, 0, 3]`` instead of ``[-1, -4, 5]``.
+    ``DirectAdjoint`` replays the subdivision instead of freezing it, which recovers it.
+    """
 
+    fun = staticmethod(lambda t, c: jnp.where(t < c[0], 1.0, 5.0).squeeze())
+    interval = jnp.array([0.0, 1.5, 3.0])
+    args = (jnp.array([1.5]),)
+    expected = np.array([-1.0, -4.0, 5.0])
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev])
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    def test_boundary_term(self, quad, transform, adjoint):
+        """Derivative w.r.t. the breakpoint picks up the jump in the integrand."""
+        f = lambda v: quad(self.fun, v, self.args, adjoint=adjoint)[0]
+        np.testing.assert_allclose(
+            np.asarray(transform(f)(self.interval)), self.expected, atol=1e-12
+        )
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    def test_matches_unrolled(self, quad):
+        """And agrees with differentiating through the loop."""
+        mk = lambda adj: lambda v: quad(self.fun, v, self.args, adjoint=adj)[0]
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(mk(_UnrolledDirectAdjoint()))(self.interval)),
+            np.asarray(jax.jacfwd(mk(DirectAdjoint()))(self.interval)),
+            rtol=ULP_RTOL,
+            atol=ULP_ATOL,
+        )
+
+
+class TestLeibnizAdjoints:
+    """The Leibniz adjoints give the derivative its own error control."""
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", SMOOTH_PROBLEMS)
+    def test_forward_matches_finite_difference(self, quad, i):
+        """Leibniz adjoint agrees with finite differences in forward mode."""
         prob = example_problems[i]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quad(prob["fun"], interval, a, adjoint=LeibnizAdjoint())[0]
+        np.testing.assert_allclose(
+            finite_difference(f, prob["args"]),
+            np.asarray(jax.jacfwd(f)(prob["args"])[0]),
+            atol=1e-4,
+            rtol=1e-4,
+        )
 
-        def integrate(args):
-            y, err = quadts(prob["fun"], prob["interval"], args, **kwargs)
-            return y
-
-        jacfd = finite_difference(integrate, prob["args"])
-        jacadf = jax.jacfwd(integrate)(prob["args"])[0]
-        jacadr = jax.jacrev(integrate)(prob["args"])[0]
-        np.testing.assert_allclose(jacfd, jacadf, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacfd, jacadr, atol=tol, rtol=tol)
-        np.testing.assert_allclose(jacadr, jacadf, atol=1e-14, rtol=1e-14)
-
-    def test_prob0(self):
-        """Test for derivative of integral of log."""
-        self._base(0, 1e-4)
-
-    def test_prob1(self):
-        """Test for derivative of integral of gaussian."""
-        self._base(1, 1e-4)
-
-
-class TestRombergJac:
-    """Tests for derivatives of romberg."""
-
-    def _base(self, i, tol, **kwargs):
-
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("i", SMOOTH_PROBLEMS)
+    def test_reverse_matches_finite_difference(self, quad, i):
+        """Leibniz adjoint agrees with finite differences in reverse mode."""
         prob = example_problems[i]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quad(prob["fun"], interval, a, adjoint=LeibnizAdjoint())[0]
+        np.testing.assert_allclose(
+            finite_difference(f, prob["args"]),
+            np.asarray(jax.jacrev(f)(prob["args"])[0]),
+            atol=1e-4,
+            rtol=1e-4,
+        )
 
-        def integrate(args):
-            y, err = romberg(prob["fun"], prob["interval"], args, **kwargs)
-            return y
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    def test_leibniz_agrees_with_direct(self, quad):
+        """Leibniz agrees with DirectAdjoint on a well resolved problem, both modes."""
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        mk = lambda adj: lambda a: quad(prob["fun"], interval, a, adjoint=adj)[0]
+        ref = np.asarray(jax.jacfwd(mk(DirectAdjoint()))(prob["args"])[0])
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(mk(LeibnizAdjoint()))(prob["args"])[0]),
+            ref,
+            rtol=1e-10,
+        )
+        np.testing.assert_allclose(
+            np.asarray(jax.jacrev(mk(LeibnizAdjoint()))(prob["args"])[0]),
+            ref,
+            rtol=1e-10,
+        )
 
-        jacfd = finite_difference(integrate, prob["args"])
-        jacadf = jax.jacfwd(integrate)(prob["args"])[0]
-        np.testing.assert_allclose(jacfd, jacadf, atol=tol, rtol=tol)
 
-    def test_prob0(self):
-        """Test for derivative of integral of log."""
-        self._base(0, 1e-4)
+class TestRomberg:
+    """Romberg supports both modes of differentiation."""
 
-    def test_prob1(self):
-        """Test for derivative of integral of gaussian."""
-        self._base(1, 1e-4)
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_direct_adjoint_supports_both_modes(self, quad):
+        """Romberg's level loop cannot be reverse differentiated directly.
+
+        DirectAdjoint gets around it by freezing the number of Richardson levels and
+        differentiating that fixed discretization through a custom primitive. Because
+        the two directions are transposes of the same linear functional, they agree to
+        rounding rather than merely to quadrature accuracy. Not asserted bitwise: the
+        integrand's own jvp and vjp can still differ in the last bit, which they do for
+        rombergts, where the integrand also carries a tanh-sinh transform.
+        """
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quad(prob["fun"], interval, a)[0]
+        fwd = np.asarray(jax.jacfwd(f)(prob["args"])[0])
+        np.testing.assert_allclose(
+            finite_difference(f, prob["args"]), fwd, atol=1e-4, rtol=1e-4
+        )
+        for rev in (jax.jacrev(f), jax.jit(jax.jacrev(f))):
+            np.testing.assert_allclose(
+                fwd, np.asarray(rev(prob["args"])[0]), rtol=ULP_RTOL, atol=ULP_ATOL
+            )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_direct_adjoint_wrt_interval(self, quad):
+        """The frozen-level path also handles derivatives of the limits."""
+        prob = example_problems[0]
+        args = prob["args"]
+        f = lambda v: quad(prob["fun"], v, args)[0]
+        iv = jnp.asarray(prob["interval"])
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(f)(iv)), np.asarray(jax.grad(f)(iv)), rtol=1e-10
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_leibniz_enables_reverse_mode(self, quad):
+        """The Leibniz adjoint makes romberg reverse mode differentiable."""
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quad(prob["fun"], interval, a, adjoint=LeibnizAdjoint())[0]
+        np.testing.assert_allclose(
+            finite_difference(f, prob["args"]),
+            np.asarray(jax.jacrev(f)(prob["args"])[0]),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_adjoint_does_not_change_the_value(self, quad):
+        """The adjoint controls derivatives only, never the returned value."""
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        ref = quad(prob["fun"], interval, prob["args"])[0]
+        for adj in [LeibnizAdjoint()]:
+            y = quad(prob["fun"], interval, prob["args"], adjoint=adj)[0]
+            np.testing.assert_array_equal(np.asarray(ref), np.asarray(y))
 
 
-class TestRombergTSJac:
-    """Tests for derivatives of rombergts."""
+class TestTransforms:
+    """Adjoints must survive the usual JAX transforms."""
 
-    def _base(self, i, tol, **kwargs):
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    def test_jit_primal(self, adjoint):
+        """The value is unchanged under jit and by the choice of adjoint."""
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda a: quadgk(prob["fun"], interval, a, adjoint=adjoint)[0]
+        np.testing.assert_array_equal(
+            np.asarray(f(prob["args"])), np.asarray(jax.jit(f)(prob["args"]))
+        )
 
-        prob = example_problems[i]
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    def test_vmap_jacfwd(self, adjoint):
+        """Forward mode works under vmap."""
+        fun = lambda t, c: jnp.log(c * t).squeeze()
+        interval = jnp.array([1.0, 3.0])
+        f = lambda c: quadgk(fun, interval, (c,), adjoint=adjoint)[0]
+        cs = jnp.array([[2.0], [3.12], [4.5]])
+        got = jax.vmap(jax.jacfwd(f))(cs)
+        want = jnp.stack([jax.jacfwd(f)(c) for c in cs])
+        np.testing.assert_allclose(np.asarray(got), np.asarray(want), rtol=1e-12)
 
-        def integrate(args):
-            y, err = rombergts(prob["fun"], prob["interval"], args, **kwargs)
-            print("y=", y)
-            print("e=", err)
-            return y
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    def test_vmap_grad(self, adjoint):
+        """Reverse mode works under vmap."""
+        fun = lambda t, c: jnp.log(c * t).squeeze()
+        interval = jnp.array([1.0, 3.0])
+        f = lambda c: quadgk(fun, interval, (c,), adjoint=adjoint)[0].sum()
+        cs = jnp.array([[2.0], [3.12], [4.5]])
+        got = jax.vmap(jax.grad(f))(cs)
+        want = jnp.stack([jax.grad(f)(c) for c in cs])
+        np.testing.assert_allclose(np.asarray(got), np.asarray(want), rtol=1e-12)
 
-        jacfd = finite_difference(integrate, prob["args"])
-        jacadf = jax.jacfwd(integrate)(prob["args"])[0]
-        np.testing.assert_allclose(jacfd, jacadf, atol=tol, rtol=tol)
+    def test_second_derivatives(self):
+        """Direct adjoint recurses, so higher derivatives work."""
+        fun = lambda t, c: jnp.exp(c[0] * t).squeeze()
+        interval = jnp.array([0.0, 1.0])
+        f = lambda c: quadgk(fun, interval, (c,), adjoint=DirectAdjoint())[0]
+        # int_0^1 exp(c t) dt = (e^c - 1)/c;  check against the unrolled reference
+        g = lambda c: quadgk(fun, interval, (c,), adjoint=_UnrolledDirectAdjoint())[0]
+        c = jnp.array([0.7])
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(jax.jacfwd(f))(c)),
+            np.asarray(jax.jacfwd(jax.jacfwd(g))(c)),
+            rtol=1e-12,
+        )
 
-    def test_prob0(self):
-        """Test for derivative of integral of log."""
-        self._base(0, 1e-4)
+    def test_closed_over_values_get_gradients(self):
+        """Values closed over by the integrand must not silently get zero gradients."""
 
-    def test_prob1(self):
-        """Test for derivative of integral of gaussian."""
-        self._base(1, 1e-4)
+        def integrate(c):
+            # c is closed over, not passed through `args`
+            return quadgk(lambda t: jnp.log(c * t), jnp.array([1.0, 3.0]))[0]
+
+        c = jnp.array(3.12)
+        expected = jax.jacfwd(
+            lambda cc: quadgk(
+                lambda t, x: jnp.log(x * t), jnp.array([1.0, 3.0]), (cc,)
+            )[0]
+        )(c)
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(integrate)(c)), np.asarray(expected), rtol=1e-12
+        )
+        np.testing.assert_allclose(
+            np.asarray(jax.grad(integrate)(c)), np.asarray(expected), rtol=1e-12
+        )
+
+
+class TestUnifiedLeibnizAdjoint:
+    """LeibnizAdjoint supports both modes from one object, via a custom primitive."""
+
+    fun = staticmethod(lambda t, c: jnp.sum(jnp.exp(-c * t)))
+    interval = jnp.array([0.0, 1.0])
+    args = jnp.linspace(0.5, 2.0, 3)
+
+    def _ref(self, quad, wrt_interval=False):
+        if wrt_interval:
+            f = lambda v: quad(self.fun, v, (self.args,), adjoint=DirectAdjoint())[0]
+            return np.asarray(jax.jacfwd(f)(self.interval))
+        f = lambda c: quad(self.fun, self.interval, (c,), adjoint=DirectAdjoint())[0]
+        return np.asarray(jax.jacfwd(f)(self.args))
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize(
+        "transform", [jax.jacfwd, jax.jacrev, jax.grad, lambda f: jax.jit(jax.grad(f))]
+    )
+    def test_both_modes_agree_with_direct(self, quad, transform):
+        """Every mode of differentiation gives the same derivative."""
+        f = lambda c: quad(self.fun, self.interval, (c,), adjoint=LeibnizAdjoint())[0]
+        np.testing.assert_allclose(
+            np.asarray(transform(f)(self.args)), self._ref(quad), rtol=1e-8
+        )
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    def test_jvp_matches_a_directional_derivative(self, quad):
+        """Forward mode contracts with the tangent rather than forming the Jacobian."""
+        f = lambda c: quad(self.fun, self.interval, (c,), adjoint=LeibnizAdjoint())[0]
+        v = jnp.ones_like(self.args)
+        np.testing.assert_allclose(
+            float(jax.jvp(f, (self.args,), (v,))[1]),
+            float(np.dot(self._ref(quad), np.asarray(v))),
+            rtol=1e-8,
+        )
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev])
+    def test_wrt_interval(self, quad, transform):
+        """Derivatives with respect to the limits work in both modes."""
+        f = lambda v: quad(self.fun, v, (self.args,), adjoint=LeibnizAdjoint())[0]
+        np.testing.assert_allclose(
+            np.asarray(transform(f)(self.interval)),
+            self._ref(quad, wrt_interval=True),
+            rtol=1e-8,
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_romberg_gets_both_modes(self, quad):
+        """Romberg is forward-only under DirectAdjoint; this gives it reverse too."""
+        f = lambda c: quad(self.fun, self.interval, (c,), adjoint=LeibnizAdjoint())[0]
+        fwd = np.asarray(jax.jacfwd(f)(self.args))
+        rev = np.asarray(jax.grad(f)(self.args))
+        np.testing.assert_allclose(fwd, rev, rtol=1e-8)
+        np.testing.assert_allclose(
+            fwd,
+            finite_difference(lambda a: f(a[0]), (self.args,)),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_vmap_and_second_derivatives(self):
+        """The primitive carries batching and composes for higher order."""
+        f = lambda c: quadgk(self.fun, self.interval, (c,), adjoint=LeibnizAdjoint())[0]
+        batch = jnp.stack([self.args, self.args * 1.1])
+        np.testing.assert_allclose(
+            np.asarray(jax.vmap(jax.grad(f))(batch)),
+            np.stack([np.asarray(jax.grad(f)(b)) for b in batch]),
+            rtol=1e-10,
+        )
+        assert np.asarray(jax.hessian(f)(self.args)).shape == (3, 3)
+
+
+@pytest.mark.parametrize("quad", all_methods)
+@pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+def test_integer_limits(quad, adjoint):
+    """Integer integration limits must still be differentiable.
+
+    They are not inexact arrays, so without being cast they end up classified as static
+    metadata rather than as values, which a custom derivative rule cannot accept.
+    """
+    fun = lambda t, c: jnp.sum(jnp.exp(-c * t))
+    c = jnp.linspace(0.5, 2.0, 3)
+    f = lambda x: quad(fun, [0, 1], (x,), adjoint=adjoint)[0]
+    g = lambda x: quad(fun, jnp.array([0.0, 1.0]), (x,), adjoint=adjoint)[0]
+    np.testing.assert_allclose(
+        np.asarray(jax.grad(f)(c)), np.asarray(jax.grad(g)(c)), rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("quad", romberg_methods)
+def test_romberg_differentiates_the_extrapolation(quad):
+    """The derivative must run through the Richardson table, not just the finest level.
+
+    Freezing the number of levels fixes *which* linear functional is applied, not which
+    parts of it are differentiated, so the result has to match differentiating the whole
+    loop exactly. Differentiating only the finest trapezoid level would still look
+    plausible while being orders of magnitude less accurate, so compare against the
+    analytic derivative too.
+    """
+    c = jnp.array([1.7])
+    fun = lambda t, cc: jnp.exp(-cc[0] * t)
+    interval = jnp.array([0.0, 1.0])
+    # d/dc int_0^1 exp(-c t) dt = [c e^-c - (1 - e^-c)] / c^2
+    exact = float((c[0] * jnp.exp(-c[0]) - (1 - jnp.exp(-c[0]))) / c[0] ** 2)
+
+    direct = lambda x: quad(fun, interval, (x,), adjoint=DirectAdjoint())[0]
+    unrolled = lambda x: quad(fun, interval, (x,), adjoint=_UnrolledDirectAdjoint())[0]
+
+    fwd = np.asarray(jax.jacfwd(direct)(c))
+    rev = np.asarray(jax.grad(lambda x: direct(x).sum())(c))
+    # Bitwise identical to differentiating the entire loop, which includes the
+    # extrapolation. This is the property that matters: it pins that the derivative runs
+    # through the whole Richardson table rather than just the finest trapezoid level.
+    np.testing.assert_array_equal(fwd, np.asarray(jax.jacfwd(unrolled)(c)))
+    # Forward and reverse are transposes of the same frozen linear functional, so they
+    # agree to within rounding. Not asserted bitwise: for rombergts the integrand also
+    # carries a tanh-sinh transform, whose own jvp and vjp can differ in the last bit.
+    np.testing.assert_allclose(fwd, rev, rtol=ULP_RTOL, atol=ULP_ATOL)
+    # and accurate to Romberg's standard, not the trapezoid rule's
+    assert abs(float(fwd[0]) - exact) < 1e-9

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -387,6 +387,25 @@ class TestTransforms:
             rtol=1e-12,
         )
 
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    def test_hessian(self, adjoint):
+        """Reverse inside forward works, not just forward inside forward.
+
+        ``jax.hessian`` is ``jacfwd(jacrev(...))``, which linearizes through the custom
+        rule rather than nesting two JVPs, and so reaches machinery that
+        ``test_second_derivatives`` does not.
+        """
+        fun = lambda t, c: jnp.sum(jnp.exp(-c * t))
+        interval = jnp.array([0.0, 1.0])
+        f = lambda c: quadgk(fun, interval, (c,), adjoint=adjoint)[0]
+        # int_0^1 sum_i exp(-c_i t) dt = sum_i (1 - exp(-c_i))/c_i, so the Hessian is
+        # diagonal; check against the unrolled reference, which carries no custom rule.
+        g = lambda c: quadgk(fun, interval, (c,), adjoint=_UnrolledDirectAdjoint())[0]
+        c = jnp.linspace(0.5, 2.0, 3)
+        got = np.asarray(jax.hessian(f)(c))
+        assert got.shape == (3, 3)
+        np.testing.assert_allclose(got, np.asarray(jax.hessian(g)(c)), rtol=1e-6)
+
     def test_closed_over_values_get_gradients(self):
         """Values closed over by the integrand must not silently get zero gradients."""
 


### PR DESCRIPTION
- Adds pluggable adjoints, controlling how derivatives of a quadrature are computed.
 ``quadgk``, ``quadcc``, ``quadts``, ``romberg``, ``rombergts``, and
 ``adaptive_quadrature`` all take a new ``adjoint`` argument, and ``AbstractAdjoint``, ``DirectAdjoint``, and ``LeibnizAdjoint`` are exported at the top level.
  - ``DirectAdjoint`` (the default) differentiates the discretization, reusing the
    subdivision the primal solve converged to. Matches old behavior but uses a much faster
    implementation.
  - ``LeibnizAdjoint`` gives the derivative its own adaptive solve, so it gets its own
    error control rather than inheriting the subdivision chosen for the integral. Often
    several times faster for a gradient of a scalar-valued integral.
- Fixed a bug in the sub-interval bookkeeping causing wrong results when the number of
  iterations reaches the max allowed (though in this case the solution is marked as
  un-converged anyways)
- ``vmap``-ed integrations should now be faster, by stopping evaluation once every batch
  element has converged, rather than running for the full ``max_ninter`` iterations
  whenever any single element still needs them. Results are unchanged.

Resolves #111 