### PR TITLE
Improve error estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ v0.3.0
 - ``vmap``-ed integrations should now be faster, by stopping evaluation once every batch
   element has converged, rather than running for the full ``max_ninter`` iterations
   whenever any single element still needs them. Results are unchanged.
+- Improved the accuracy of the error estimates used by all the adaptive integrators.
+  Reported ``err`` values and iteration counts change throughout, and integrands whose
+  error was previously under-estimated now take more work to reach a given tolerance.
+  Some integrations that used to report ``status == 0`` while quietly missing the
+  requested tolerance now report a non-zero status instead; the values they return are
+  more accurate than before, not less.
+- ``status`` is no longer set on an iteration that reaches the requested tolerance. An
+  integration that converged just as it ran out of sub-intervals previously reported
+  ``MAX_NINTER`` despite having succeeded.
+- Integrands that are simply unresolved, rather than limited by roundoff, are no longer
+  written off as ``ROUNDOFF`` while they are still converging.
+- Asking for a tolerance tighter than the arithmetic can deliver is now reported as
+  ``ROUNDOFF``, rather than subdividing until the ``max_ninter`` limit is reached. Such
+  integrations also finish sooner.
+- The reported error estimate can no longer come back negative.
+- ``y_abs`` and ``y_mmn`` returned by ``AbstractQuadratureRule.integrate`` are now the
+  integrals over ``[a, b]`` that their docstrings describe; they were previously scaled
+  by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or implementing
+  a custom one.
 - **Breaking**: removed ``fixed_quadgk``, ``fixed_quadcc``, and ``fixed_quadts``,
   deprecated since v0.2.2. Use ``GaussKronrodRule``, ``ClenshawCurtisRule``, and
   ``TanhSinhRule`` instead, eg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ v0.3.0
   ``ROUNDOFF``, rather than subdividing until the ``max_ninter`` limit is reached. Such
   integrations also finish sooner.
 - The reported error estimate can no longer come back negative.
+- Documented when the nested-rule error estimate can under-state the true error: on
+  integrands sampled at fewer than about three points per oscillation (any rule, any
+  order), on endpoint singularities under ``ClenshawCurtisRule``, and for
+  ``TanhSinhRule`` below order 15. Behaviour is unchanged; this is guidance only.
 - ``y_abs`` and ``y_mmn`` returned by ``AbstractQuadratureRule.integrate`` are now the
   integrals over ``[a, b]`` that their docstrings describe; they were previously scaled
   by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or implementing

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -601,6 +601,27 @@ def _rebuild_mesh(interval, frozen):
     return lo + frac_a * width, lo + frac_b * width
 
 
+def _at_roundoff_floor(state, epmach, norm):
+    """Report whether the error has bottomed out while still above the tolerance.
+
+    The local rule floors each sub-interval's error estimate at ``50*eps*int|f|`` over
+    that sub-interval, so the total can never fall below that floor summed over the
+    partition -- and that sum stays near ``50*eps*int|f|`` over the whole domain however
+    finely the mesh is refined. Once the total has reached the floor and is still above
+    ``err_bnd``, no amount of further subdivision will reach the requested tolerance,
+    because the tolerance is below what the arithmetic can resolve.
+
+    QUADPACK makes this test only in its initial phase, before the subdivision loop, so
+    a request below the achievable precision is left to exhaust the subdivision budget
+    and report that instead. quadax makes it every iteration, which reports the actual
+    difficulty and stops early.
+    """
+    intabs = norm(jnp.sum(state["f_arr"], axis=0))
+    return (state["err_sum"] <= 100.0 * epmach * intabs) & (
+        state["err_sum"] > state["err_bnd"]
+    )
+
+
 def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter):
     """Run the globally adaptive subdivision loop."""
     intfun = partial(rule.integrate, **kwargs) if kwargs else rule.integrate
@@ -621,6 +642,9 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
     state["s_arr"] = jnp.zeros(
         (max_ninter, *shape), f.dtype
     )  # global est. of I from n intervals
+    state["f_arr"] = jnp.zeros(
+        (max_ninter, *shape), f.dtype
+    )  # local est. of integral of abs(fun) from each interval
     state["a_arr"] = state["a_arr"].at[: state["ninter"]].set(interval[:-1])
     state["b_arr"] = state["b_arr"].at[: state["ninter"]].set(interval[1:])
     state["roundoff1"] = 0  # for keeping track of roundoff errors
@@ -641,30 +665,24 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
     state["frac_a"] = jnp.zeros(max_ninter)
     state["frac_b"] = jnp.zeros(max_ninter).at[: state["ninter"]].set(1.0)
 
-    def init_body(i, state_):
-        state, intabs_ = state_
+    def init_body(i, state):
         a = state["a_arr"][i]
         b = state["b_arr"][i]
         result, abserr, intabs, intmmn = intfun(vfunc, a, b, ())
 
-        intabs_ += intabs
         state["neval"] += 1
-        state["area"] += result
-        state["err_sum"] += abserr
         state["r_arr"] = state["r_arr"].at[i].set(result)
         state["e_arr"] = state["e_arr"].at[i].set(abserr)
+        state["f_arr"] = state["f_arr"].at[i].set(intabs)
+        state["area"] = jnp.sum(state["r_arr"], axis=0)
+        state["err_sum"] = jnp.sum(state["e_arr"])
         state["s_arr"] = state["s_arr"].at[i].set(state["area"])
-        return state, intabs_
+        return state
 
-    state, intabs_ = jax.lax.fori_loop(
-        0, state["ninter"], init_body, (state, jnp.zeros(shape))
-    )
+    state = jax.lax.fori_loop(0, state["ninter"], init_body, state)
     state["err_bnd"] = jnp.maximum(epsabs, epsrel * _norm(state["area"]))
     # check for roundoff error - error too big but relative error is small
-    state["status"] += 2**ROUNDOFF * (
-        (state["err_sum"] <= (100.0 * epmach * _norm(intabs_)))
-        & (state["err_sum"] > state["err_bnd"])
-    )
+    state["status"] += 2**ROUNDOFF * _at_roundoff_floor(state, epmach, _norm)
 
     # check for max intervals exceeded
     state["status"] += 2**MAX_NINTER * (state["ninter"] >= max_ninter)
@@ -699,32 +717,94 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
         # improve previous approximations to integral and error and test for accuracy.
         area12 = area1 + area2
         erro12 = error1 + error2
-        state["err_sum"] += erro12 - state["e_arr"][i]
-        state["area"] += area12 - state["r_arr"][i]
-        state["r_arr"] = state["r_arr"].at[i].set(area1)
-        state["r_arr"] = state["r_arr"].at[n].set(area2)
+        # The parent's contribution and error estimate, read before either is
+        # overwritten below. These are QUADPACK's `rlist(maxerr)`/`errmax`, and the
+        # stagnation test further down compares against the *parent*, so they have to be
+        # captured here rather than read back out of the arrays.
+        area_i = state["r_arr"][i]
+        err_i = state["e_arr"][i]
+
+        # Which half keeps slot `i` and which takes the new slot `n`: as in QUADPACK the
+        # larger error goes first. Only the placement depends on this, not either total,
+        # so both arrays are written here and the branch at the end of the body is left
+        # with the endpoints and the fractions.
+        swap = error2 > error1
+
+        def place(arr, x1, x2):
+            """Write the two halves into slots `i` and `n`, ordered by `swap`."""
+            return (
+                arr.at[i]
+                .set(jnp.where(swap, x2, x1))
+                .at[n]
+                .set(jnp.where(swap, x1, x2))
+            )
+
+        state["e_arr"] = place(state["e_arr"], error1, error2)
+        state["r_arr"] = place(state["r_arr"], area1, area2)
+        state["f_arr"] = place(state["f_arr"], intabs1, intabs2)
+
+        # Both running totals are summed afresh from the per-interval contributions
+        # rather than carried forward as `total += new - old`. Accumulating discards
+        # ~eps times the largest term ever subtracted on every iteration, and that drift
+        # random-walks while the total it is tracking shrinks. For `err_sum` the two
+        # move in opposite directions and the drift can outgrow the total outright: on
+        # an integrand with a tall narrow peak it goes negative, and the loop then exits
+        # through the `0 <= err_sum` guard in `condfun` with `status` still 0, reporting
+        # a nonsense error estimate and a clean bill of health. Summing afresh keeps the
+        # error at O(eps * total)
+        state["err_sum"] = jnp.sum(state["e_arr"])
+        state["area"] = jnp.sum(state["r_arr"], axis=0)
         state["s_arr"] = state["s_arr"].at[n].set(state["area"])
         state["err_bnd"] = jnp.maximum(epsabs, epsrel * _norm(state["area"]))
+
+        # Did the local rule resolve both halves at all? The error estimate saturates at
+        # exactly the integral of |f - <f>| when the rule learned nothing about that
+        # half, in which case a stagnant area is evidence of an unresolved integrand
+        # rather than of roundoff, and QUADPACK skips both counters. Without this a hard
+        # but tractable integrand accumulates stagnation counts while it is still making
+        # legitimate progress. The equality is exact on purpose: it asks whether the
+        # `min(1, ...)` clamped, not whether two quantities are merely close. Both sides
+        # go through `_norm` because that is the reduction the error estimate itself
+        # already went through for vector valued integrands.
+        resolved = (error1 != _norm(intmmn1)) & (error2 != _norm(intmmn2))
 
         # test for roundoff error
         # is the area estimate not changing and error not getting smaller?
         state["roundoff1"] += (
-            _norm(state["r_arr"][i] - area12) <= 0.1e-4 * _norm(area12)
-        ) & (erro12 >= 0.99 * jnp.max(state["e_arr"]))
-        # are errors getting larger as we go to smaller intervals?
-        state["roundoff2"] += (state["ninter"] > 10) & (
-            erro12 > jnp.max(state["e_arr"])
+            resolved
+            & (_norm(area_i - area12) <= 0.1e-4 * _norm(area12))
+            & (erro12 >= 0.99 * err_i)
         )
-        state["status"] += 2**ROUNDOFF * (
-            (state["roundoff1"] >= 10) | (state["roundoff2"] >= 20)
+        # are errors getting larger as we go to smaller intervals?
+        state["roundoff2"] += resolved & (state["ninter"] > 10) & (erro12 > err_i)
+
+        # Whether the tolerance was reached on this iteration. QUADPACK jumps past
+        # every `ier` assignment once `errsum <= errbnd`, so an iteration that both
+        # reaches the tolerance and, say, consumes the last subdivision slot still exits
+        # cleanly. The counters above are still updated, matching the original.
+        converged = state["err_sum"] <= state["err_bnd"]
+
+        # Roundoff is reported either because the error has bottomed out at the floor
+        # the arithmetic imposes, or because the two counters say subdivision has
+        # stopped buying anything.
+        state["status"] += (
+            2**ROUNDOFF
+            * ~converged
+            * (
+                _at_roundoff_floor(state, epmach, _norm)
+                | (state["roundoff1"] >= 10)
+                | (state["roundoff2"] >= 20)
+            )
         )
 
         # test for max number of intervals
-        state["status"] += 2**MAX_NINTER * (state["ninter"] >= max_ninter)
+        state["status"] += 2**MAX_NINTER * ~converged * (state["ninter"] >= max_ninter)
 
         # test for bad behavior of the integrand (ie, intervals are getting too small)
-        state["status"] += 2**BAD_INTEGRAND * (
-            jnp.maximum(jnp.abs(b1 - a1), jnp.abs(b2 - a2)) <= (100.0 * epmach)
+        state["status"] += (
+            2**BAD_INTEGRAND
+            * ~converged
+            * (jnp.maximum(jnp.abs(b1 - a1), jnp.abs(b2 - a2)) <= (100.0 * epmach))
         )
 
         # update the arrays of interval starts/ends etc
@@ -737,12 +817,12 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
         frac_mid = 0.5 * (frac_a1 + frac_b2)
         state["owner"] = state["owner"].at[n].set(owner_i)
 
+        # `e_arr` and `r_arr` were placed above; what is left is to give the two halves
+        # the endpoints and fractions matching the slots they landed in.
         def error1big(state):
             state["a_arr"] = state["a_arr"].at[n].set(a2)
             state["b_arr"] = state["b_arr"].at[i].set(b1)
             state["b_arr"] = state["b_arr"].at[n].set(b2)
-            state["e_arr"] = state["e_arr"].at[i].set(error1)
-            state["e_arr"] = state["e_arr"].at[n].set(error2)
             state["frac_b"] = state["frac_b"].at[i].set(frac_mid)
             state["frac_a"] = state["frac_a"].at[n].set(frac_mid)
             state["frac_b"] = state["frac_b"].at[n].set(frac_b2)
@@ -752,16 +832,12 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
             state["a_arr"] = state["a_arr"].at[i].set(a2)
             state["a_arr"] = state["a_arr"].at[n].set(a1)
             state["b_arr"] = state["b_arr"].at[n].set(b1)
-            state["r_arr"] = state["r_arr"].at[i].set(area2)
-            state["r_arr"] = state["r_arr"].at[n].set(area1)
-            state["e_arr"] = state["e_arr"].at[i].set(error2)
-            state["e_arr"] = state["e_arr"].at[n].set(error1)
             state["frac_a"] = state["frac_a"].at[i].set(frac_mid)
             state["frac_a"] = state["frac_a"].at[n].set(frac_a1)
             state["frac_b"] = state["frac_b"].at[n].set(frac_mid)
             return state
 
-        state = jax.lax.cond(error2 > error1, error2big, error1big, state)
+        state = jax.lax.cond(swap, error2big, error1big, state)
         return state
 
     state = bounded_while_loop(condfun, bodyfun, state, max_ninter + 1)

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -104,6 +104,16 @@ class NestedRule(AbstractQuadratureRule):
     Nested rules consist of a set of nodes (xh) and weights (wh) for a high order rule,
     along with an additional set of weights (wl) for a lower order rule that shares
     nodes with the high order rule.
+
+    Notes
+    -----
+    The error estimate is derived from the difference between the two rules, so it is
+    only meaningful while the nodes resolve the integrand. For oscillatory integrands,
+    below roughly three points per oscillation both rules alias and agree spuriously,
+    and the estimate can fall well below the true error; above roughly eight it is
+    reliably conservative. This is a property of nested rules in general rather than of
+    any particular order, since raising the order only raises the frequency at which it
+    sets in. Strongly oscillatory integrands are better served by a specialized method.
     """
 
     _xh: jax.Array
@@ -263,6 +273,13 @@ class ClenshawCurtisRule(NestedRule):
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+
+    Notes
+    -----
+    On integrands with an endpoint singularity the error estimate can under-state the
+    true error, increasingly so at higher order, because the endpoint-clustered nodes
+    make the two rules agree while neither has converged. An adaptive integration may
+    then report success while missing the requested tolerance.
     """
 
     def __init__(self, order: int = 32, norm: Callable | float | int = jnp.inf):
@@ -306,6 +323,13 @@ class TanhSinhRule(NestedRule):
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+
+    Notes
+    -----
+    Below about order 15 the embedded rule is too coarse for the error estimate to be
+    trusted on any integrand with structure, including peaked and endpoint-singular ones
+    that the other rules handle at much lower order; halving the points of a
+    doubly-exponential rule costs far more accuracy than halving a polynomial one.
     """
 
     def __init__(self, order: int = 61, norm: Callable | float | int = jnp.inf):

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -114,6 +114,13 @@ class NestedRule(AbstractQuadratureRule):
     reliably conservative. This is a property of nested rules in general rather than of
     any particular order, since raising the order only raises the frequency at which it
     sets in. Strongly oscillatory integrands are better served by a specialized method.
+
+    References
+    ----------
+    .. [1] R. Piessens, E. de Doncker-Kapenga, C. W. Überhuber, D. K. Kahaner.
+           "QUADPACK: A Subroutine Package for Automatic Integration". Springer Series
+           in Computational Mathematics, vol. 1. Springer-Verlag, Berlin, 1983.
+           doi:10.1007/978-3-642-61786-7
     """
 
     _xh: jax.Array
@@ -187,12 +194,49 @@ class NestedRule(AbstractQuadratureRule):
 
             uflow = jnp.finfo(f.dtype).tiny
             eps = jnp.finfo(f.dtype).eps
+
+            # The difference between the two rules is dominated by the error of the
+            # *low* order one, so it says little about the error of ``result``, which
+            # comes from the high order rule and is typically far smaller. It is only a
+            # starting point, and is rescaled below rather than reported directly.
             abserr = jnp.abs(result_kronrod - result_gauss)
+
+            # Measure that discrepancy against how much the integrand varies over the
+            # interval. This rescaling, and the 200 and 1.5 in it, are QUADPACK's, fit
+            # empirically there rather than derived; see [1] and the ``dqk*`` routines,
+            # which use the same two constants at every order from 15 through 61.
+            # With ``r = abserr / integral_mmn`` the estimate becomes
+            # ``integral_mmn * min(1, (200*r)**1.5)``, which has three regimes:
+            #   - ``r >= 1/200``: saturate at ``integral_mmn``. The rules disagree at
+            #     the scale of the variation of the integrand, so nothing has been
+            #     resolved and the whole variation is the only honest bound.
+            #   - middle: inflate the raw difference, by up to ~200x. This is most of
+            #     the useful range, so the rescaling is usually pessimistic rather than
+            #     optimistic, contrary to how the formula first reads.
+            #   - ``r < 200**-1.5``: deflate, the regime where the two rules agree to
+            #     near machine precision and the difference genuinely overstates the
+            #     error of the high order rule.
+            # The exponent is the ratio of the two rules' convergence rates: a rule
+            # exact to degree ``d`` has local error ``~h**(d+2)``, giving
+            # ``(d_high+2)/(d_low+2)``. 1.5 is the large-order limit of that ratio for
+            # Gauss-Kronrod, and a lower bound across every rule implemented here, so it
+            # is the conservative choice, a larger exponent would shrink the estimate.
+            # The guard covers a constant integrand, where ``integral_mmn`` is zero and
+            # the ratio would be 0/0.
             abserr = jnp.where(
                 (integral_mmn != 0.0) & (abserr != 0.0),
                 integral_mmn * jnp.minimum(1.0, (200.0 * abserr / integral_mmn) ** 1.5),
                 abserr,
             )
+
+            # No error estimate can be meaningful below the noise of the evaluation
+            # itself. This floor is not a count of summed terms (XLA's pairwise
+            # reduction holds summation error near ``eps`` whatever the rule size) but
+            # covers the conditioning of the integrand: nodes carry ``~eps*|x|``, which
+            # the integrand amplifies by ``|f'|``, so the achievable accuracy degrades
+            # as the integrand varies faster. 50 is a compromise across that, generous
+            # for smooth integrands and mildly optimistic for strongly oscillatory ones.
+            # The ``uflow`` guard keeps the product from underflowing to zero.
             abserr = jnp.where(
                 (integral_abs > uflow / (50.0 * eps)),
                 jnp.maximum((eps * 50.0) * integral_abs, abserr),

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -159,9 +159,18 @@ class NestedRule(AbstractQuadratureRule):
             result_kronrod = _dot(self._wh, f) * halflength
             result_gauss = _dot(self._wl, f) * halflength
 
-            integral_abs = _dot(self._wh, jnp.abs(f))  # ~integral of abs(fun)
-            integral_mmn = _dot(
-                self._wh, jnp.abs(f - result_kronrod / (b - a))
+            # Both of these are sums over the reference interval [-1, 1] and so, like
+            # the two results above, need the Jacobian of the map onto [a, b] to be an
+            # estimate of an integral over [a, b]. QUADPACK scales all four by
+            # ``dhlgth``; the error estimate below compares ``abserr`` against
+            # ``integral_mmn``, so the two have to be on the same scale for the
+            # ``200 ... **1.5`` interpolation to mean what it was tuned to mean.
+            dhalflength = jnp.abs(halflength)
+            integral_abs = (
+                _dot(self._wh, jnp.abs(f)) * dhalflength
+            )  # ~integral of abs(fun)
+            integral_mmn = (
+                _dot(self._wh, jnp.abs(f - result_kronrod / (b - a))) * dhalflength
             )  # ~ integral of abs(fun - mean(fun))
 
             result = result_kronrod

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -7,7 +7,14 @@ import pytest
 import scipy
 from jax import config
 
-from quadax import quadcc, quadgk, quadts, romberg, rombergts
+import quadax
+from quadax import (
+    quadcc,
+    quadgk,
+    quadts,
+    romberg,
+    rombergts,
+)
 
 config.update("jax_enable_x64", True)
 
@@ -161,25 +168,28 @@ class TestQuadGK:
     def test_prob6(self):
         """Test for example problem #6."""
         self._base(6, 1e-4, order=15)
-        self._base(6, 1e-8, 100, order=15)
+        # endpoint singularity: order 15 tops out around 1e-8 however much budget it is
+        # given, so it exhausts the subdivision limit rather than reaching the tolerance
+        self._base(6, 1e-8, 100, order=15, status=2)
         self._base(6, 1e-12, 1e5, order=15, max_ninter=100, status=8)
 
     def test_prob7(self):
         """Test for example problem #7."""
         self._base(7, 1e-4, order=61)
         self._base(7, 1e-8, order=61)
-        self._base(7, 1e-12, order=61, status=4)
+        self._base(7, 1e-12, order=61)
 
     def test_prob8(self):
         """Test for example problem #8."""
         self._base(8, 1e-4, order=51)
         self._base(8, 1e-8, order=51)
-        self._base(8, 1e-12, order=51, status=4)
+        self._base(8, 1e-12, order=51)
 
     def test_prob9(self):
         """Test for example problem #9."""
         self._base(9, 1e-4, order=15)
-        self._base(9, 1e-8, 100, order=15)
+        # as for problem 6, order 15 cannot certify 1e-8 on this endpoint singularity
+        self._base(9, 1e-8, 100, order=15, status=2)
         self._base(9, 1e-12, 1e4, order=15, max_ninter=100, status=8)
 
     def test_prob10(self):
@@ -191,7 +201,9 @@ class TestQuadGK:
     def test_prob11(self):
         """Test for example problem #11."""
         self._base(11, 1e-4, order=21)
-        self._base(11, 1e-8, 100, order=21)
+        # bisection concentrates on the singularity at t=0 until the sub-intervals stop
+        # being resolvable, at a true error just above 1e-8
+        self._base(11, 1e-8, 100, order=21, status=8)
         self._base(11, 1e-12, 1e4, order=21, status=8, max_ninter=100)
 
     def test_prob12(self):
@@ -288,20 +300,21 @@ class TestQuadCC:
     def test_prob6(self):
         """Test for example problem #6."""
         self._base(6, 1e-4)
-        self._base(6, 1e-8, 100)
+        # endpoint singularity, see TestQuadGK.test_prob6
+        self._base(6, 1e-8, 100, status=2)
         self._base(6, 1e-12, 1e5, max_ninter=100, status=8)
 
     def test_prob7(self):
         """Test for example problem #7."""
         self._base(7, 1e-4)
         self._base(7, 1e-8, 10)
-        self._base(7, 1e-12, status=8)
+        self._base(7, 1e-12)
 
     def test_prob8(self):
         """Test for example problem #8."""
         self._base(8, 1e-4)
         self._base(8, 1e-8)
-        self._base(8, 1e-12, status=8)
+        self._base(8, 1e-12)
 
     def test_prob9(self):
         """Test for example problem #9."""
@@ -318,7 +331,8 @@ class TestQuadCC:
     def test_prob11(self):
         """Test for example problem #11."""
         self._base(11, 1e-4)
-        self._base(11, 1e-8, 100)
+        # singularity at t=0, see TestQuadGK.test_prob11
+        self._base(11, 1e-8, 100, status=8)
         self._base(11, 1e-12, 1e4, status=8)
 
     def test_prob12(self):
@@ -392,7 +406,11 @@ class TestQuadTS:
         """Test for example problem #2."""
         self._base(2, 1e-4, order=41)
         self._base(2, 1e-8, order=41)
-        self._base(2, 1e-12, order=41)
+        # The answer here is exact to machine precision, but at order 41 the error
+        # *estimate* comes down slowly enough that it is still ~15% above the bound when
+        # the subdivision limit is reached (a larger max_ninter does get under it). The
+        # value is still checked against 1e-12 below.
+        self._base(2, 1e-12, order=41, status=2)
 
     def test_prob3(self):
         """Test for example problem #3."""
@@ -416,7 +434,7 @@ class TestQuadTS:
         """Test for example problem #6."""
         self._base(6, 1e-4)
         self._base(6, 1e-8)
-        self._base(6, 1e-12, 1e4, status=4)
+        self._base(6, 1e-12, 1e4, status=8)
 
     def test_prob7(self):
         """Test for example problem #7."""
@@ -446,7 +464,7 @@ class TestQuadTS:
         """Test for example problem #11."""
         self._base(11, 1e-4)
         self._base(11, 1e-8)
-        self._base(11, 1e-12, 1e4, status=4)
+        self._base(11, 1e-12, 1e4, status=2)
 
     def test_prob12(self):
         """Test for example problem #12."""
@@ -785,3 +803,68 @@ def test_truncated_result_is_still_a_partition(quad):
     np.testing.assert_allclose(a[0], -1.0, atol=1e-14)
     np.testing.assert_allclose(b[-1], 1.0, atol=1e-14)
     np.testing.assert_allclose(a[1:], b[:-1], atol=1e-14)
+
+
+@pytest.mark.parametrize("max_ninter", [22, 23, 24, 25, 26])
+def test_converged_iteration_exits_clean(max_ninter):
+    """Meeting the tolerance as the budget runs out is not a failure.
+
+    QUADPACK jumps past every ``ier`` assignment once ``errsum <= errbnd``, so an
+    iteration that reaches the tolerance exits with ``ier = 0`` even if it also
+    consumed the last subdivision slot. The flags used to be set unconditionally, with
+    termination left to the loop predicate on the next pass, so an iteration that did
+    both reported a spurious failure.
+    """
+    tol = 1e-10
+    y, info = quadgk(
+        lambda t: jnp.log(t),
+        jnp.array([0.0, 1.0]),
+        epsabs=tol,
+        epsrel=tol,
+        max_ninter=max_ninter,
+    )
+    err = float(info.err)
+    if 0 <= err <= max(tol, tol * abs(float(y))):
+        assert int(info.status) == 0, f"reported failure at err={err:.3e} <= {tol:.0e}"
+
+
+# A tall narrow peak: 1e8 at its top, integral 3.1e4, so the error estimates the loop
+# starts from are ~15 orders of magnitude above the total it ends at.
+_PEAK = lambda t: 1 / ((t - 0.5) ** 2 + 1e-8)
+_PEAK_VAL = 31411.926535951257  # mpmath, split at the peak
+
+
+def test_no_spurious_roundoff_on_unresolved_integrand():
+    """A peaked but tractable integrand must not be written off as roundoff-limited.
+
+    Two regressions here. The stagnation test compared the bisected halves against
+    ``r_arr[i]`` *after* it had been overwritten with the left half, so it was really
+    asking whether the right half was negligible rather than whether subdivision had
+    stopped moving the parent's value. And neither counter was gated on QUADPACK's
+    ``defab == error`` check, which suppresses them when the local rule did not resolve
+    a half at all, since a stagnant area is then evidence of an unresolved integrand
+    rather than of roundoff. Together they made the loop give up early here, reporting
+    ROUNDOFF with an error five orders of magnitude worse than achievable.
+    """
+    y, info = quadgk(_PEAK, jnp.array([0.0, 1.0]), epsabs=1e-12, epsrel=1e-12)
+    assert int(info.status) == 0, quadax.STATUS[int(info.status)]
+    np.testing.assert_allclose(float(y), _PEAK_VAL, rtol=1e-13, atol=0)
+
+
+def test_tolerance_below_roundoff_floor_reports_roundoff():
+    """Asking for more precision than the arithmetic allows is a ROUNDOFF verdict.
+
+    The local rule floors each sub-interval's error estimate at ``50*eps*int|f|``, so
+    the total cannot fall below that floor summed over the partition however fine the
+    mesh gets. Here that floor is ~1.1e-14 relative, so a request of 1e-14 is out of
+    reach.
+    quadax tests for this only before the subdivision loop, as QUADPACK does, which left
+    such a request to burn through the whole subdivision budget and report MAX_NINTER --
+    true, but not the reason.
+    """
+    _, info = quadgk(_PEAK, jnp.array([0.0, 1.0]), epsabs=1e-14, epsrel=1e-14)
+    assert int(info.status) & 2**2, quadax.STATUS[int(info.status)]
+    # and the error it stopped at really is the accumulated floor
+    np.testing.assert_allclose(
+        float(info.err), 50 * np.finfo(np.float64).eps * _PEAK_VAL, rtol=1e-3
+    )


### PR DESCRIPTION
- Improved the accuracy of the error estimates used by all the adaptive integrators.
  Reported ``err`` values and iteration counts change throughout, and integrands whose
  error was previously under-estimated now take more work to reach a given tolerance.
  Some integrations that used to report ``status == 0`` while quietly missing the
  requested tolerance now report a non-zero status instead; the values they return are
  more accurate than before, not less.
- ``status`` is no longer set on an iteration that reaches the requested tolerance. An
  integration that converged just as it ran out of sub-intervals previously reported
  ``MAX_NINTER`` despite having succeeded.
- Integrands that are simply unresolved, rather than limited by roundoff, are no longer
  written off as ``ROUNDOFF`` while they are still converging.
- Asking for a tolerance tighter than the arithmetic can deliver is now reported as
  ``ROUNDOFF``, rather than subdividing until the ``max_ninter`` limit is reached. Such
  integrations also finish sooner.
- The reported error estimate can no longer come back negative.
- Documented when the nested-rule error estimate can under-state the true error: on
  integrands sampled at fewer than about three points per oscillation (any rule, any
  order), on endpoint singularities under ``ClenshawCurtisRule``, and for
  ``TanhSinhRule`` below order 15. Behaviour is unchanged; this is guidance only.
- ``y_abs`` and ``y_mmn`` returned by ``AbstractQuadratureRule.integrate`` are now the
  integrals over ``[a, b]`` that their docstrings describe; they were previously scaled
  by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or implementing
  a custom one.


Resolves #13 