### PR TITLE
Better support for single and half precision dtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,30 @@ v0.3.0
   ``quadax.AbstractQuadratureRule``.
 - **Breaking**: removed the unused ``norm`` argument to ``adaptive_quadrature``. It had
   no effect; the norm is taken from the rule, ie ``GaussKronrodRule(order, norm)``.
+- quadax now works in the precision you ask for, rather than always in whatever
+  `jax_enable_x64` happens to make the default. The dtype of `interval` is how you ask:
+  the integrand is called with an `x` of that dtype, and the result follows it unless
+  the integrand upcasts internally, in which case that is respected too. `float16`,
+  `bfloat16`, `float32`, `float64` and complex integrands are all supported, and the
+  default `epsabs`/`epsrel` follow the working dtype. See "Precision and dtypes" in the
+  documentation.
+  - Fixes a `TypeError` from `map_interval` that made *any* explicitly-dtyped `interval`
+    other than the default unusable, on all of `quadgk`, `quadcc`, `quadts`, `romberg`
+    and `rombergts`, for finite and infinite intervals alike.
+  - Fixes a `TypeError` from `GaussKronrodRule`/`ClenshawCurtisRule`/`TanhSinhRule`'s
+    `integrate` when the integrand's dtype was not the JAX default.
+  - The node and weight tables are now built in float64 on the host and rounded once to
+    the working dtype. Previously the Clenshaw-Curtis and tanh-sinh tables were
+    *computed* in float32 whenever x64 was off, which is less accurate. Building them
+    with numpy also makes them independent of the backend's transcendental functions,
+    which are not all as accurate as the host's; as a result `quadts` and `rombergts`
+    results move in the last ulp or two. `quadgk` and `quadcc` are bit-identical.
+  - `simpson` and `cumulative_simpson` no longer return the default float dtype
+    regardless of their inputs.
+  - No change for float64, or for any configuration that worked before: the default
+    tolerances resolve to exactly what they used to in each case.
+- `quadts` and `rombergts` now warn when used at `float16`/`bfloat16`, where the
+  tanh-sinh clustering can no longer get close enough to an endpoint to be worth having.
 - Packaging metadata moved from ``setup.py``/``setup.cfg`` into ``pyproject.toml``.
   Development dependencies are now declared as extras rather than in requirements
   files, so use ``pip install -e ".[dev]"`` (or the narrower ``test``, ``docs``, and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,68 @@ Do you only know your integrand at discrete points?
 - Use ``trapezoid`` or ``simspson``
 
 
+Precision and dtypes
+====================
+The dtype of ``interval`` is how you ask for a precision, and quadax works in it
+throughout. Everything else follows from that and from the integrand:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - what
+     - dtype
+   * - the ``x`` your integrand is called with, and the sub-interval endpoints
+     - the dtype of ``interval``
+   * - the returned integral
+     - ``jnp.result_type(interval.dtype, fun(x).dtype)``
+   * - the reported ``err``, and ``epsabs``/``epsrel``
+     - the real counterpart of the above
+   * - the default ``epsabs``/``epsrel``
+     - ``sqrt(eps)`` of whichever of the first and third is coarser
+
+So to integrate in single precision, say so::
+
+    y, info = quadgk(fun, jnp.array([0.0, 1.0], dtype=jnp.float32))
+
+Note that JAX itself defaults to 32 bit, and silently narrows a float64 array to float32
+unless x64 is enabled::
+
+    import jax
+    jax.config.update("jax_enable_x64", True)
+
+A plain python list or an integer ``interval`` carries no dtype of its own, and falls
+back to the JAX default, so ``quadgk(fun, [0.0, 1.0])`` is float64 with x64 on and
+float32 without.
+
+An integrand that upcasts on purpose is respected. It is still *called* with an ``x`` at
+the precision you asked for, but its own output dtype is carried through, so this returns
+float64 while only ever evaluating ``fun`` at float32 abscissae::
+
+    quadgk(lambda x: g(x.astype(jnp.float64)), jnp.array([0.0, 1.0], dtype=jnp.float32))
+
+Complex integrands are supported. The limits themselves must be real -- the subdivision
+has to be able to order the breakpoints -- and ``err`` stays real.
+
+Reduced precision
+-----------------
+``float16`` and ``bfloat16`` work and return valid results, with two caveats worth
+knowing before you rely on them.
+
+The error estimate stops being sharp. quadax uses QUADPACK's estimator, which floors
+each sub-interval's error at ``50*eps`` times the integral of ``|f|`` there. In half
+precision that floor sits above the point where the estimator would otherwise refine, so
+it saturates and reports the total variation of the integrand over the sub-interval. That
+is a genuine upper bound on the error, and never an under-estimate, but it is a loose
+one, and it will make the adaptive methods subdivide more than they need to.
+
+``quadts`` and ``rombergts`` lose most of what makes them special, and say so with a
+``UserWarning``. Their double exponential clustering can only place a node about
+``10*eps`` of the half width away from an endpoint -- 2.2e-15 at float64, but 7.8e-2 at
+bfloat16 -- so at half precision there is no longer any real clustering near the
+singularity. Use ``quadgk`` or ``quadcc`` there, or move to float32.
+
+
 Notes on parallel efficiency
 ============================
 Adaptive algorithms are inherently somewhat sequential, so perfect parallelism

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -22,7 +22,13 @@ from .fixed_order import (
     GaussKronrodRule,
     TanhSinhRule,
 )
-from .utils import QuadratureInfo, _get_eps, bounded_while_loop, errorif
+from .utils import (
+    QuadratureInfo,
+    _real_dtype,
+    bounded_while_loop,
+    errorif,
+    resolve_dtypes,
+)
 
 NORMAL_EXIT = 0
 MAX_NINTER = 1
@@ -62,17 +68,22 @@ def quadgk(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration with possible breakpoints. Use np.inf to
-        denote infinite intervals.
+        denote infinite intervals. Its dtype sets the working precision: the integrand
+        is called with an ``x`` of this dtype, and the result follows it unless the
+        integrand upcasts. A integer types or python floats falls back to the JAX
+        default. Must be real; complex integrands are supported, complex limits are not.
     args : tuple, optional
         Extra arguments passed to fun.
     full_output : bool, optional
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is square root of
-        machine precision. Algorithm tries to obtain an accuracy of
-        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
-        `fun` over `interval`, and ``result`` is the numerical approximation.
+        Absolute and relative error tolerance. Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two. Algorithm tries to obtain an
+        accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` =
+        integral of `fun` over `interval`, and ``result`` is the numerical
+        approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -172,17 +183,22 @@ def quadcc(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration with possible breakpoints. Use np.inf to
-        denote infinite intervals.
+        denote infinite intervals. Its dtype sets the working precision: the integrand
+        is called with an ``x`` of this dtype, and the result follows it unless the
+        integrand upcasts. A integer types or python floats falls back to the JAX
+        default. Must be real; complex integrands are supported, complex limits are not.
     args : tuple, optional
         Extra arguments passed to fun.
     full_output : bool, optional
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is square root of
-        machine precision. Algorithm tries to obtain an accuracy of
-        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
-        `fun` over `interval`, and ``result`` is the numerical approximation.
+        Absolute and relative error tolerance. Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two. Algorithm tries to obtain an
+        accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` =
+        integral of `fun` over `interval`, and ``result`` is the numerical
+        approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -281,17 +297,22 @@ def quadts(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration with possible breakpoints. Use np.inf to
-        denote infinite intervals.
+        denote infinite intervals. Its dtype sets the working precision: the integrand
+        is called with an ``x`` of this dtype, and the result follows it unless the
+        integrand upcasts. A integer types or python floats falls back to the JAX
+        default. Must be real; complex integrands are supported, complex limits are not.
     args : tuple, optional
         Extra arguments passed to fun.
     full_output : bool, optional
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is square root of
-        machine precision. Algorithm tries to obtain an accuracy of
-        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
-        `fun` over `interval`, and ``result`` is the numerical approximation.
+        Absolute and relative error tolerance. Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two. Algorithm tries to obtain an
+        accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` =
+        integral of `fun` over `interval`, and ``result`` is the numerical
+        approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -390,17 +411,22 @@ def adaptive_quadrature(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration with possible breakpoints. Use np.inf to
-        denote infinite intervals.
+        denote infinite intervals. Its dtype sets the working precision: the integrand
+        is called with an ``x`` of this dtype, and the result follows it unless the
+        integrand upcasts. A integer types or python floats falls back to the JAX
+        default. Must be real; complex integrands are supported, complex limits are not.
     args : tuple, optional
         Extra arguments passed to fun.
     full_output : bool, optional
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float, optional
-        Absolute and relative error tolerance. Default is square root of
-        machine precision. Algorithm tries to obtain an accuracy of
-        ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` = integral of
-        `fun` over `interval`, and ``result`` is the numerical approximation.
+        Absolute and relative error tolerance. Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two. Algorithm tries to obtain an
+        accuracy of ``abs(i-result) <= max(epsabs, epsrel*abs(i))`` where ``i`` =
+        integral of `fun` over `interval`, and ``result`` is the numerical
+        approximation.
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
@@ -460,14 +486,15 @@ def adaptive_quadrature(
         ValueError,
         f"max_ninter={max_ninter} is not enough for {len(interval) - 1} breakpoints",
     )
+    dtypes = resolve_dtypes(interval, fun, args)
     if epsabs is None:
-        epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
+        epsabs = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
     if epsrel is None:
-        epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
-    epsabs = jnp.asarray(epsabs)
-    epsrel = jnp.asarray(epsrel)
+        epsrel = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
+    epsabs = jnp.asarray(epsabs, dtypes.etype)
+    epsrel = jnp.asarray(epsrel, dtypes.etype)
 
-    f_conv, consts = closure_convert(fun, args)
+    f_conv, consts = closure_convert(fun, args, dtypes.xtype)
 
     ops = QuadratureOps(
         build=partial(build_integrand, f_conv=f_conv),
@@ -536,10 +563,13 @@ def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
         -1, chunk
     )
     a_c, b_c = reshape(a_safe, a_arr[0]), reshape(b_safe, b_arr[0])
-    used_c = reshape(used.astype(a_arr.dtype), 0.0)
 
     apply1 = lambda a, b: rule._apply(vfunc, a, b, ())
     sds = jax.eval_shape(apply1, a_arr[0], b_arr[0])
+    # The mask multiplies the *values*, so it takes their (real) dtype rather than the
+    # mesh's. With the mesh at float64 and the values at float32 the latter would
+    # otherwise be promoted straight back to float64 here.
+    used_c = reshape(used.astype(_real_dtype(sds.dtype)), 0.0)
 
     def bodyfun(total, block):
         a, b, m = block
@@ -627,32 +657,45 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
     intfun = partial(rule.integrate, **kwargs) if kwargs else rule.integrate
     _norm = rule.norm
     f = jax.eval_shape(vfunc, (interval[0] + interval[-1]) / 2)
-    epmach = _get_eps(f)
     shape = f.shape
+    # Derived here rather than threaded in, so that this stays correct when the adjoints
+    # call it with a tangent integrand whose dtype is not the primal's. `vfunc` has
+    # already been through `map_interval`, whose Jacobian is at `xtype`, so its output
+    # dtype is the accumulation dtype by construction.
+    xtype = interval.dtype
+    ytype = f.dtype
+    etype = _real_dtype(ytype)  # errors and the integral of |f| are real
+    # Roundoff in the arithmetic that forms the sums, versus roundoff in the mesh: the
+    # first bounds how small an error estimate can honestly be, the second how narrow a
+    # sub-interval can get before its endpoints stop being distinguishable.
+    epmach = float(jnp.finfo(etype).eps)
+    epmach_x = float(jnp.finfo(xtype).eps)
 
     state = {}
     state["neval"] = 0  # number of evaluations of local quadrature rule
     state["ninter"] = len(interval) - 1  # current number of intervals
     state["r_arr"] = jnp.zeros(
-        (max_ninter, *shape), f.dtype
+        (max_ninter, *shape), ytype
     )  # local results from each interval
-    state["e_arr"] = jnp.zeros(max_ninter)  # local error est. from each interval
-    state["a_arr"] = jnp.zeros(max_ninter)  # start of each interval
-    state["b_arr"] = jnp.zeros(max_ninter)  # end of each interval
+    state["e_arr"] = jnp.zeros(max_ninter, etype)  # local error est. from each interval
+    state["a_arr"] = jnp.zeros(max_ninter, xtype)  # start of each interval
+    state["b_arr"] = jnp.zeros(max_ninter, xtype)  # end of each interval
     state["s_arr"] = jnp.zeros(
-        (max_ninter, *shape), f.dtype
+        (max_ninter, *shape), ytype
     )  # global est. of I from n intervals
     state["f_arr"] = jnp.zeros(
-        (max_ninter, *shape), f.dtype
+        (max_ninter, *shape), etype
     )  # local est. of integral of abs(fun) from each interval
     state["a_arr"] = state["a_arr"].at[: state["ninter"]].set(interval[:-1])
     state["b_arr"] = state["b_arr"].at[: state["ninter"]].set(interval[1:])
     state["roundoff1"] = 0  # for keeping track of roundoff errors
     state["roundoff2"] = 0  # for keeping track of roundoff errors
     state["status"] = 0  # error flag
-    state["err_bnd"] = 0.0  # error bound we're trying to reach
-    state["area"] = jnp.zeros(shape, f.dtype)  # current best estimate for I
-    state["err_sum"] = 0.0  # current estimate for error in I
+    # Explicitly typed rather than left as weak python floats: these are `scan` carries,
+    # so their dtype has to match what the loop body writes back into them.
+    state["err_bnd"] = jnp.zeros((), etype)  # error bound we're trying to reach
+    state["area"] = jnp.zeros(shape, ytype)  # current best estimate for I
+    state["err_sum"] = jnp.zeros((), etype)  # current estimate for error in I
     # Where each sub-interval sits relative to the *original* sub-intervals: which one
     # it was carved out of, and the fractions of the way along it that its ends lie at.
     # These are what stay fixed when a limit or breakpoint moves, so recording them lets
@@ -662,8 +705,8 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
         .at[: state["ninter"]]
         .set(jnp.arange(state["ninter"]))
     )
-    state["frac_a"] = jnp.zeros(max_ninter)
-    state["frac_b"] = jnp.zeros(max_ninter).at[: state["ninter"]].set(1.0)
+    state["frac_a"] = jnp.zeros(max_ninter, xtype)
+    state["frac_b"] = jnp.zeros(max_ninter, xtype).at[: state["ninter"]].set(1.0)
 
     def init_body(i, state):
         a = state["a_arr"][i]
@@ -770,9 +813,16 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
 
         # test for roundoff error
         # is the area estimate not changing and error not getting smaller?
+        # QUADPACK's threshold is a flat 1e-5, which is only meaningful while it sits
+        # above the noise floor of the difference it is applied to, ~eps*|area12|. It
+        # does at float32 and float64 (`50*eps` is 6e-6 and 1.1e-14, so the maximum is
+        # 1e-5 either way and this is QUADPACK's test unchanged) but not in half
+        # precision, where a flat 1e-5 is below the noise and this counter could never
+        # fire. `50` is the same as in the local rule's roundoff floor.
+        stagnant = max(1e-5, 50 * epmach)
         state["roundoff1"] += (
             resolved
-            & (_norm(area_i - area12) <= 0.1e-4 * _norm(area12))
+            & (_norm(area_i - area12) <= stagnant * _norm(area12))
             & (erro12 >= 0.99 * err_i)
         )
         # are errors getting larger as we go to smaller intervals?
@@ -801,10 +851,12 @@ def _adaptive_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter
         state["status"] += 2**MAX_NINTER * ~converged * (state["ninter"] >= max_ninter)
 
         # test for bad behavior of the integrand (ie, intervals are getting too small)
+        # This one is about the *mesh*, not the values, so it scales with the precision
+        # the abscissae are carried at rather than the precision of the sums.
         state["status"] += (
             2**BAD_INTEGRAND
             * ~converged
-            * (jnp.maximum(jnp.abs(b1 - a1), jnp.abs(b2 - a2)) <= (100.0 * epmach))
+            * (jnp.maximum(jnp.abs(b1 - a1), jnp.abs(b2 - a2)) <= (100.0 * epmach_x))
         )
 
         # update the arrays of interval starts/ends etc

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -29,15 +29,20 @@ class _ConvertedFunction(eqx.Module):
         return self.f_conv(x, self.args, *self.consts)
 
 
-def closure_convert(fun, args):
+def closure_convert(fun, args, xtype):
     """Hoist values closed over by ``fun`` so that they are visible to AD.
 
     Custom derivative rules only see their explicit arguments. Anything ``fun`` closes
     over would otherwise silently get a zero gradient, so pull it out into ``consts``
     and pass it in explicitly.
+
+    ``xtype`` is the dtype the abscissa will be carried at. It matters here rather
+    than only downstream because ``closure_convert`` traces ``fun`` to a jaxpr at the
+    dtype it is given, and that jaxpr is what every later evaluation of the integrand
+    goes through.
     """
     f_conv, consts = jax.closure_convert(
-        lambda x, args_: fun(x, *args_), jnp.array(0.0), args
+        lambda x, args_: fun(x, *args_), jnp.zeros((), xtype), args
     )
     return f_conv, tuple(consts)
 
@@ -46,7 +51,7 @@ def build_integrand(interval, args, consts, *, f_conv):
     """Map the integrand to the reference domain and wrap it for vectorization."""
     fun = _ConvertedFunction(f_conv, args, consts)
     fun_mapped, interval_t = map_interval(fun, interval)
-    return wrap_func(fun_mapped, ()), interval_t
+    return wrap_func(fun_mapped, (), interval_t.dtype), interval_t
 
 
 class QuadratureOps(NamedTuple):

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -8,8 +8,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from .quad_weights import gk_weights
-from .utils import wrap_func
+from .quad_weights import get_cc_table, get_tanhsinh_table, gk_weights
+from .utils import _real_dtype, tanhsinh_tmax, wrap_func
 
 
 def _dot(w, f):
@@ -128,6 +128,20 @@ class NestedRule(AbstractQuadratureRule):
     _wl: jax.Array
     _norm: float | int | Callable
 
+    def _nodes_weights(self, xtype) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Nodes and weights of the rule for use at abscissa dtype ``xtype``.
+
+        The tables are stored at the highest precision available and cast at the point
+        of use, so a float64 user loses nothing and a float32 user gets a table rounded
+        once from float64 rather than one computed in float32. Only the nodes are cast
+        here; the weights are cast to the accumulation dtype by the caller, which cannot
+        know it until the integrand has been evaluated.
+
+        Subclasses whose *table itself* depends on the precision rather than merely
+        being rounded to it should override this. See ``TanhSinhRule``.
+        """
+        return self._xh.astype(xtype), self._wh, self._wl
+
     @eqx.filter_jit
     def integrate(
         self,
@@ -161,20 +175,25 @@ class NestedRule(AbstractQuadratureRule):
             is the mean value of fun over the interval.
 
         """
-        vfun = wrap_func(fun, args)
-
-        def truefun():
-            f = jax.eval_shape(vfun, jnp.array(0.0))
-            z = jnp.zeros(f.shape, f.dtype)
-            return z, self.norm(z), jnp.abs(z), jnp.abs(z)
+        # The dtype of the limits is the statement of what precision was asked for: the
+        # abscissae, and so the `x` the user's integrand sees, follow it.
+        xtype = jnp.result_type(a, b)
+        vfun = wrap_func(fun, args, xtype)
+        xh, wh_table, wl_table = self._nodes_weights(xtype)
 
         def falsefun():
 
             halflength = (b - a) / 2
             center = (b + a) / 2
-            f: jax.Array = vfun(center + halflength * self._xh)
-            result_kronrod = _dot(self._wh, f) * halflength
-            result_gauss = _dot(self._wl, f) * halflength
+            f: jax.Array = vfun(center + halflength * xh)
+            # An integrand that upcasts internally is respected, so the accumulation
+            # follows both the limits and the integrand. The weights are cast to the
+            # *real* counterpart, which lets a complex integrand promote on its own.
+            etype = _real_dtype(jnp.result_type(xtype, f.dtype))
+            wh = wh_table.astype(etype)
+            wl = wl_table.astype(etype)
+            result_kronrod = _dot(wh, f) * halflength
+            result_gauss = _dot(wl, f) * halflength
 
             # Both of these are sums over the reference interval [-1, 1] and so, like
             # the two results above, need the Jacobian of the map onto [a, b] to be an
@@ -183,17 +202,19 @@ class NestedRule(AbstractQuadratureRule):
             # ``integral_mmn``, so the two have to be on the same scale for the
             # ``200 ... **1.5`` interpolation to mean what it was tuned to mean.
             dhalflength = jnp.abs(halflength)
-            integral_abs = (
-                _dot(self._wh, jnp.abs(f)) * dhalflength
-            )  # ~integral of abs(fun)
+            integral_abs = _dot(wh, jnp.abs(f)) * dhalflength  # ~integral of abs(fun)
             integral_mmn = (
-                _dot(self._wh, jnp.abs(f - result_kronrod / (b - a))) * dhalflength
+                _dot(wh, jnp.abs(f - result_kronrod / (b - a))) * dhalflength
             )  # ~ integral of abs(fun - mean(fun))
 
             result = result_kronrod
 
-            uflow = jnp.finfo(f.dtype).tiny
-            eps = jnp.finfo(f.dtype).eps
+            # Compile time constants, taken as python floats rather than as arrays of
+            # the working dtype: `uflow / (50 * eps)` evaluated *in* half precision is a
+            # needless underflow risk, and as a weakly typed python float the threshold
+            # promotes to whatever it is compared against anyway.
+            uflow = float(jnp.finfo(etype).tiny)
+            eps = float(jnp.finfo(etype).eps)
 
             # The difference between the two rules is dominated by the error of the
             # *low* order one, so it says little about the error of ``result``, which
@@ -234,10 +255,17 @@ class NestedRule(AbstractQuadratureRule):
             # which a smooth enough integrand does reach.
             scalable = (integral_mmn != 0.0) & (abserr != 0.0)
             mmn_safe = jnp.where(scalable, integral_mmn, 1.0)
-            ratio = jnp.where(scalable, 200.0 * abserr / mmn_safe, 1.0)
+            ratio = jnp.where(scalable, abserr / mmn_safe, 1.0)
+
+            # The saturation is applied inside the power rather than outside it:
+            # forming ``200 * ratio`` first overflows in half precision for any
+            # ``ratio > 328``, and the result is then discarded by the outer ``min``
+            # regardless. The inner clamp is the identity whenever the outer one is, so
+            # this is bit for bit ``min(1, (200*ratio)**1.5)`` wherever that expression
+            # does not overflow.
             abserr = jnp.where(
                 scalable,
-                integral_mmn * jnp.minimum(1.0, ratio**1.5),
+                integral_mmn * jnp.minimum(200.0 * jnp.minimum(ratio, 1.0), 1.0) ** 1.5,
                 abserr,
             )
 
@@ -256,6 +284,11 @@ class NestedRule(AbstractQuadratureRule):
             )
             return result, self.norm(abserr), integral_abs, integral_mmn
 
+        def truefun():
+            # Zeros shaped and typed exactly like what the other branch produces.
+            out = jax.eval_shape(falsefun)
+            return jax.tree.map(lambda s: jnp.zeros(s.shape, s.dtype), out)
+
         return jax.lax.cond(a == b, truefun, falsefun)
 
     @eqx.filter_jit
@@ -271,11 +304,14 @@ class NestedRule(AbstractQuadratureRule):
         Only the high order rule is summed, skipping the low order rule and the two
         auxiliary sums that ``integrate`` needs for its error estimate.
         """
-        vfun = wrap_func(fun, args)
+        xtype = jnp.result_type(a, b)
+        vfun = wrap_func(fun, args, xtype)
+        xh, wh_table, _ = self._nodes_weights(xtype)
         halflength = (b - a) / 2
         center = (b + a) / 2
-        f: jax.Array = vfun(center + halflength * self._xh)
-        return _dot(self._wh, f) * halflength
+        f: jax.Array = vfun(center + halflength * xh)
+        etype = _real_dtype(jnp.result_type(xtype, f.dtype))
+        return _dot(wh_table.astype(etype), f) * halflength
 
     def norm(self, x: jax.Array) -> jax.Array:
         """Norm to use for measuring error for vector valued integrands."""
@@ -340,29 +376,9 @@ class ClenshawCurtisRule(NestedRule):
 
     def __init__(self, order: int = 32, norm: Callable | float | int = jnp.inf):
         self._norm = norm
-
-        def _cc_get_weights(N):
-            d = 2 / (1 - (jnp.arange(0, N + 1, 2)) ** 2)
-            d = d.at[0].multiply(1 / 2)
-            d = d.at[-1].multiply(1 / 2)
-            k = jnp.arange(N // 2 + 1)
-            n = jnp.arange(N // 2 + 1)
-            D = 2 / N * jnp.cos(k[:, None] * n[None, :] * jnp.pi / (N // 2))
-            D = jnp.where((n == 0) | (n == N // 2), D * 1 / 2, D)
-            w = D.T @ d  # can be done faster with fft
-            t = jnp.arange(0, 1 + N // 2) * jnp.pi / N
-            x = jnp.cos(t)
-            w = w.at[-1].multiply(2)
-            return x, w
-
         order = 2 * (order // 2)  # make sure its even
-        xh, wh = _cc_get_weights(order)
-        wl = _cc_get_weights(order // 2)[1]
-        wl = jnp.zeros_like(wh).at[::2].set(wl)
-
-        self._xh = jnp.concatenate([xh, -xh[:-1][::-1]])
-        self._wh = jnp.concatenate([wh, wh[:-1][::-1]])
-        self._wl = jnp.concatenate([wl, wl[:-1][::-1]])
+        xh, wh, wl = get_cc_table(order)
+        self._xh, self._wh, self._wl = jnp.asarray(xh), jnp.asarray(wh), jnp.asarray(wl)
 
 
 class TanhSinhRule(NestedRule):
@@ -388,35 +404,27 @@ class TanhSinhRule(NestedRule):
     doubly-exponential rule costs far more accuracy than halving a polynomial one.
     """
 
+    _order: int
+
     def __init__(self, order: int = 61, norm: Callable | float | int = jnp.inf):
         self._norm = norm
-
-        _xts = lambda t: jnp.tanh(jnp.pi / 2 * jnp.sinh(t))
-        _wts = lambda t: (
-            jnp.pi / 2 * jnp.cosh(t) / jnp.cosh(jnp.pi / 2 * jnp.sinh(t)) ** 2
+        self._order = 2 * (order // 2) + 1  # make sure its odd
+        # The stored table is the one for the default dtype; `_nodes_weights` rebuilds
+        # it whenever the quadrature actually runs at a different precision.
+        xh, wh, wl = get_tanhsinh_table(
+            self._order, tanhsinh_tmax(jnp.result_type(float))
         )
+        self._xh, self._wh, self._wl = jnp.asarray(xh), jnp.asarray(wh), jnp.asarray(wl)
 
-        def _get_tmax(xmax):
-            # Inverse of tanh-sinh transform.
-            tanhinv = lambda x: 1 / 2 * jnp.log((1 + x) / (1 - x))
-            sinhinv = lambda x: jnp.log(x + jnp.sqrt(x**2 + 1))
-            return sinhinv(2 / jnp.pi * tanhinv(xmax))
+    def _nodes_weights(self, xtype) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Rebuild the table at ``xtype`` rather than casting the stored one.
 
-        tmax = _get_tmax(jnp.array(1.0) - 10 * jnp.finfo(jnp.array(1.0).dtype).eps)
-        a, b = -tmax, tmax
-
-        order = 2 * (order // 2) + 1  # make sure its odd
-
-        th = jnp.linspace(a, b, order)
-        tl = jnp.linspace(a, b, order // 2 + 1)
-
-        xh = _xts(th)
-        wh = _wts(th) * jnp.diff(th)[0]
-        wl = _wts(tl) * jnp.diff(tl)[0]
-        wl = jnp.zeros_like(wh).at[::2].set(wl)
-        wh *= 2 / wh.sum()
-        wl *= 2 / wl.sum()
-
-        self._xh = xh
-        self._wh = wh
-        self._wl = wl
+        The tanh-sinh nodes are cut off at the last one still distinct from the
+        endpoint, so the extent of the table -- not just its rounding -- depends on the
+        precision it will be used at. Casting a float64 table down to bfloat16 would
+        collapse its outer nodes onto the endpoint and silently drop the effective
+        order; rebuilding spreads the same ``order`` nodes over the range that dtype can
+        actually resolve.
+        """
+        xh, wh, wl = get_tanhsinh_table(self._order, tanhsinh_tmax(xtype))
+        return jnp.asarray(xh, xtype), jnp.asarray(wh), jnp.asarray(wl)

--- a/quadax/quad_weights.py
+++ b/quadax/quad_weights.py
@@ -1,5 +1,7 @@
 """Quadrature nodes and weights."""
 
+import functools
+
 import numpy as np
 
 kronrod_15_weights = np.array(
@@ -768,3 +770,59 @@ gk_weights = {
         "wg": gauss_30_weights,
     },
 }
+
+
+@functools.lru_cache
+def get_cc_table(order: int):
+    """Clenshaw-Curtis nodes and weights, built in float64 on the host.
+
+    In numpy rather than with ``jnp`` ops so that the table does not inherit whatever
+    the JAX default dtype happens to be. Building the DCT matrix in float32 and using it
+    in float32 is strictly worse than building it in float64 and rounding it once.
+    """
+
+    def _cc_get_weights(N):
+        d = 2 / (1 - np.arange(0, N + 1, 2, dtype=float) ** 2)
+        d[0] *= 1 / 2
+        d[-1] *= 1 / 2
+        k = np.arange(N // 2 + 1)
+        n = np.arange(N // 2 + 1)
+        D = 2 / N * np.cos(k[:, None] * n[None, :] * np.pi / (N // 2))
+        D = np.where((n == 0) | (n == N // 2), D * 1 / 2, D)
+        w = D.T @ d  # can be done faster with fft
+        t = np.arange(0, 1 + N // 2) * np.pi / N
+        x = np.cos(t)
+        w[-1] *= 2
+        return x, w
+
+    xh, wh = _cc_get_weights(order)
+    wl = np.zeros_like(wh)
+    wl[::2] = _cc_get_weights(order // 2)[1]
+
+    return (
+        np.concatenate([xh, -xh[:-1][::-1]]),
+        np.concatenate([wh, wh[:-1][::-1]]),
+        np.concatenate([wl, wl[:-1][::-1]]),
+    )
+
+
+@functools.lru_cache
+def get_tanhsinh_table(order: int, tmax: float):
+    """Tanh-sinh nodes and weights on ``[-tmax, tmax]``, built in float64 on the host.
+
+    ``tmax`` is a parameter rather than being derived here because it depends on the
+    precision the nodes will be *used* at; see ``quadax.utils.tanhsinh_tmax``.
+    """
+    _xts = lambda t: np.tanh(np.pi / 2 * np.sinh(t))
+    _wts = lambda t: np.pi / 2 * np.cosh(t) / np.cosh(np.pi / 2 * np.sinh(t)) ** 2
+
+    th = np.linspace(-tmax, tmax, order)
+    tl = np.linspace(-tmax, tmax, order // 2 + 1)
+
+    xh = _xts(th)
+    wh = _wts(th) * np.diff(th)[0]
+    wl = np.zeros_like(wh)
+    wl[::2] = _wts(tl) * np.diff(tl)[0]
+    wh *= 2 / wh.sum()
+    wl *= 2 / wl.sum()
+    return xh, wh, wl

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -18,11 +18,12 @@ from .adjoint import (
 )
 from .utils import (
     QuadratureInfo,
-    _get_eps,
     _pnorm,
+    _real_dtype,
     bounded_while_loop,
     errorif,
     map_interval,
+    resolve_dtypes,
     tanhsinh_transform,
     wrap_func,
 )
@@ -55,6 +56,10 @@ def romberg(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration. Use np.inf to denote infinite intervals.
+        Its dtype sets the working precision: the integrand is called with an ``x`` of
+        this dtype, and the result follows it unless the integrand upcasts. A integer
+        types or python floats falls back to the JAX default. Must be real; complex
+        integrands are supported, complex limits are not.
     args : tuple
         additional arguments passed to fun
     full_output : bool, optional
@@ -63,8 +68,9 @@ def romberg(
     epsabs, epsrel : float
         Absolute and relative tolerances. If I1 and I2 are two
         successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is square root of
-        machine precision.
+        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two.
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at
@@ -117,12 +123,13 @@ def romberg(
         NotImplementedError,
         "Romberg integration with breakpoints not supported",
     )
+    dtypes = resolve_dtypes(interval, fun, args)
     if epsabs is None:
-        epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
+        epsabs = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
     if epsrel is None:
-        epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
-    epsabs = jnp.asarray(epsabs)
-    epsrel = jnp.asarray(epsrel)
+        epsrel = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
+    epsabs = jnp.asarray(epsabs, dtypes.etype)
+    epsrel = jnp.asarray(epsrel, dtypes.etype)
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -139,17 +146,28 @@ def romberg(
         _norm,
         adjoint,
         build_integrand,
+        dtypes.xtype,
     )
 
 
 def _romberg(
-    fun, interval, args, full_output, epsabs, epsrel, divmax, _norm, adjoint, build
+    fun,
+    interval,
+    args,
+    full_output,
+    epsabs,
+    epsrel,
+    divmax,
+    _norm,
+    adjoint,
+    build,
+    xtype,
 ):
     """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
     # Closure conversion has to happen on the user's function, before any wrapping:
     # once a transformed integrand crosses a filter_jit boundary its leaves become
     # tracers that closure_convert cannot hoist.
-    f_conv, consts = closure_convert(fun, args)
+    f_conv, consts = closure_convert(fun, args, xtype)
     # Romberg has no subdivision to reuse, so `rebuild`/`on_mesh` are left unset and
     # DirectAdjoint falls back to differentiating through the loop.
     ops = QuadratureOps(
@@ -175,7 +193,7 @@ def _build_tanhsinh(interval, args, consts, *, f_conv):
     fun = _ConvertedFunction(f_conv, args, consts)
     fun_t, interval_t = tanhsinh_transform(fun, interval)
     fun_m, interval_m = map_interval(fun_t, interval_t)
-    return wrap_func(fun_m, ()), interval_m
+    return wrap_func(fun_m, (), interval_m.dtype), interval_m
 
 
 def _romberg_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, divmax, _norm):
@@ -187,7 +205,10 @@ def _romberg_solve(rule, vfunc, interval, epsabs, epsrel, kwargs, *, divmax, _no
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
     result = result.at[0, 0].set(vfunc(a) + vfunc(b))
     neval = 2
-    err = jnp.inf
+    # Explicitly typed rather than left a weak python float: this is a loop carry, and
+    # has to match what `_norm` writes back into it. Real, because the error in a
+    # complex valued integral is still real.
+    err = jnp.array(jnp.inf, _real_dtype(f.dtype))
     state = (result, 1, neval, err)
 
     def ncond(state):
@@ -296,6 +317,10 @@ def rombergts(
         ``fun(x, *args)`` -> float, Array. Should be JAX transformable.
     interval : array-like
         Lower and upper limits of integration. Use np.inf to denote infinite intervals.
+        Its dtype sets the working precision: the integrand is called with an ``x`` of
+        this dtype, and the result follows it unless the integrand upcasts. A integer
+        types or python floats falls back to the JAX default. Must be real; complex
+        integrands are supported, complex limits are not.
     args : tuple
         additional arguments passed to fun
     full_output : bool, optional
@@ -304,8 +329,9 @@ def rombergts(
     epsabs, epsrel : float
         Absolute and relative tolerances. If I1 and I2 are two
         successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is square root of
-        machine precision.
+        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is the square root of the
+        machine precision of the working dtype, ie of `interval`, or of the integrand's
+        own dtype if that is the coarser of the two.
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at
@@ -359,12 +385,13 @@ def rombergts(
         NotImplementedError,
         "tanh-sinh transformation with breakpoints not supported",
     )
+    dtypes = resolve_dtypes(interval, fun, args)
     if epsabs is None:
-        epsabs = jnp.sqrt(_get_eps(jnp.array(1.0)))
+        epsabs = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
     if epsrel is None:
-        epsrel = jnp.sqrt(_get_eps(jnp.array(1.0)))
-    epsabs = jnp.asarray(epsabs)
-    epsrel = jnp.asarray(epsrel)
+        epsrel = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
+    epsabs = jnp.asarray(epsabs, dtypes.etype)
+    epsrel = jnp.asarray(epsrel, dtypes.etype)
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -381,4 +408,5 @@ def rombergts(
         _norm,
         adjoint,
         _build_tanhsinh,
+        dtypes.xtype,
     )

--- a/quadax/sampled.py
+++ b/quadax/sampled.py
@@ -220,8 +220,10 @@ def _basic_simpson(
         h = jnp.diff(x, axis=axis)
         sl0 = _tupleset(slice_all, axis, slice(start, stop, step))
         sl1 = _tupleset(slice_all, axis, slice(start + 1, stop + 1, step))
-        h0 = h[sl0].astype(float)
-        h1 = h[sl1].astype(float)
+        # The spacings only need to be made *inexact*; a plain `.astype(float)` would
+        # also drag an already-float32 `x` up to float64 under x64.
+        h0 = _ensure_float_array(h[sl0])
+        h1 = _ensure_float_array(h[sl1])
         hsum = h0 + h1
         hprod = h0 * h1
         h0divh1 = jnp.where(h1 == 0, 0, h0 / h1)
@@ -287,8 +289,12 @@ def simpson(
             raise ValueError("If given, length of x along axis must be the same as y.")
 
     if N % 2 == 0:
-        val = jnp.array(0.0)
-        result = jnp.array(0.0)
+        # Weak python floats rather than `jnp.array(0.0)`. The latter is a *strong*
+        # array at the default dtype, so under x64 it dragged the whole even-N branch up
+        # to float64 regardless of what `y` and `x` were; these just take the dtype of
+        # whatever they are combined with.
+        val = 0.0
+        result = 0.0
         slice_all = (slice(None),) * nd
 
         if N == 2:
@@ -309,7 +315,7 @@ def simpson(
             slice2 = _tupleset(slice_all, axis, -2)
             slice3 = _tupleset(slice_all, axis, -3)
 
-            h = jnp.asarray([dx, dx])
+            h = jnp.full((2,), dx, _float_dtype(y))
             if x is not None:
                 # grab the last two spacings from the appropriate axis
                 hm2 = _tupleset(slice_all, axis, slice(-2, -1, 1))
@@ -345,7 +351,7 @@ def simpson(
 
             result += alpha * y[slice1] + beta * y[slice2] - eta * y[slice3]
 
-        result = result + val
+        result = jnp.asarray(result + val)
     else:
         result = _basic_simpson(y, 0, N - 2, x, dx, axis)
     return result
@@ -492,7 +498,7 @@ def _cumulatively_sum_simpson_integrals(
 
     shape = list(sub_integrals_h1.shape)
     shape[-1] += 1
-    sub_integrals = jnp.empty(shape)
+    sub_integrals = jnp.empty(shape, sub_integrals_h1.dtype)
     sub_integrals = sub_integrals.at[..., :-1:2].set(sub_integrals_h1[..., ::2])
     sub_integrals = sub_integrals.at[..., 1::2].set(sub_integrals_h2[..., ::2])
     # Integral over last subinterval can only be calculated from
@@ -530,6 +536,19 @@ def _cumulative_simpson_unequal_intervals(y: jax.Array, dx: jax.Array) -> jax.Ar
     coeff3 = -x21x21_x31x32
 
     return x21 / 6 * (coeff1 * f1 + coeff2 * f2 + coeff3 * f3)
+
+
+def _float_dtype(arr: ArrayLike):
+    """The dtype of ``arr``, made inexact.
+
+    The working dtype of a sampled integral: whatever the samples are carried at, except
+    that integer samples fall back to the default float, since there is no float dtype
+    they imply.
+    """
+    dtype = jnp.asarray(arr).dtype
+    if jnp.issubdtype(dtype, jnp.integer):
+        return jnp.result_type(float)
+    return dtype
 
 
 def _ensure_float_array(arr: ArrayLike) -> jax.Array:

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -1,12 +1,14 @@
 """Utility functions for parsing inputs, mapping coordinates etc."""
 
 import functools
+import warnings
 from collections.abc import Callable
 from typing import Any, NamedTuple
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 from equinox.internal import unvmap_any
 from jax.typing import ArrayLike
 
@@ -19,6 +21,69 @@ def errorif(cond: bool | jax.Array, err: type[Exception] = ValueError, msg: str 
     """
     if cond:
         raise err(msg)
+
+
+class DTypes(NamedTuple):
+    """The working dtypes of a quadrature.
+
+    quadax takes the dtype of ``interval`` as the statement of what precision the user
+    wants, and derives everything else from it and from the integrand. An integrand that
+    deliberately upcasts is respected: it is still *called* with an abscissa at the
+    requested precision, but its own output dtype is carried through to the result.
+
+    Parameters
+    ----------
+    xtype : dtype
+        Abscissae. The sub-interval endpoints, the node tables, and the ``x`` the user's
+        integrand is called with. Taken from ``interval``.
+    ytype : dtype
+        Integrand values, the per-interval contributions, and the returned integral. May
+        be complex.
+    etype : dtype
+        Real. Weight tables, error estimates, tolerances. The real counterpart of
+        ``ytype``, so that a complex integrand contracted with real weights promotes to
+        complex on its own.
+    toltype : dtype
+        Real. Sets the default ``epsabs``/``epsrel`` of ``sqrt(eps)``. The coarser of
+        ``xtype`` and ``etype``: a float32 abscissa limits the achievable accuracy
+        however precisely the integrand itself is evaluated.
+
+    """
+
+    xtype: Any
+    ytype: Any
+    etype: Any
+    toltype: Any
+
+
+def _real_dtype(dtype) -> Any:
+    """Real counterpart of ``dtype`` (float32 for complex64, and itself for real)."""
+    return jnp.finfo(dtype).dtype
+
+
+def _coarser_dtype(dtype1, dtype2) -> Any:
+    """Whichever of the two has the larger machine epsilon."""
+    if float(jnp.finfo(dtype1).eps) >= float(jnp.finfo(dtype2).eps):
+        return dtype1
+    return dtype2
+
+
+def resolve_dtypes(
+    interval: jax.Array, fun: Callable[..., jax.Array], args: tuple[Any, ...] = ()
+) -> DTypes:
+    """Work out the dtypes of a quadrature from its limits and its integrand.
+
+    The single point at which quadax decides what precision it is working in. See
+    :class:`DTypes` for what each one governs.
+    """
+    xtype = jnp.asarray(interval).dtype
+    # `jnp.zeros((), xtype)` rather than `jnp.array(0.0)`: the latter is *weakly* typed,
+    # which both hides the requested precision and lets different expressions involving
+    # it settle on different dtypes. See the note on `MAPFUNS`.
+    f = jax.eval_shape(fun, jnp.zeros((), xtype), *args)
+    ytype = jnp.result_type(xtype, f.dtype)
+    etype = _real_dtype(ytype)
+    return DTypes(xtype, ytype, etype, _coarser_dtype(xtype, etype))
 
 
 def _map_linear(t: jax.Array, a: jax.Array, b: jax.Array):
@@ -80,6 +145,14 @@ def _map_ninfb_inv(x: jax.Array, a: jax.Array, b: jax.Array):
 MAPFUNS = [_map_linear, _map_ninfb, _map_ainf, _map_ninfinf]
 MAPFUNS_INV = [_map_linear_inv, _map_ninfb_inv, _map_ainf_inv, _map_ninfinf_inv]
 
+# These are the branches of a `lax.switch`, so all four have to return the same dtypes,
+# and they only do so if `t`, `a` and `b` agree. Note in particular that they must not
+# be given a *weakly* typed `t`: the four differ in which of `a`/`b` they use, and a
+# weak `t` lets each branch settle on whichever of the two is present. `_map_linear`'s
+# `c * jnp.ones_like(t)` would follow a strong float32 `a`, while `_map_ninfb`'s
+# `2 / (t + 1) ** 2` would stay at the weak default, and the switch would not build.
+# This is why the integrand is probed with `jnp.zeros((), xtype)`, not `jnp.array(0.0)`.
+
 
 def map_interval(fun: Callable[..., jax.Array], interval: ArrayLike):
     """Map a function over an arbitrary interval [a, b] to the interval [-1, 1].
@@ -103,8 +176,17 @@ def map_interval(fun: Callable[..., jax.Array], interval: ArrayLike):
         New lower and upper limits of integration with possible breakpoints.
     """
     interval = jnp.asarray(interval)
+    errorif(
+        not jnp.issubdtype(interval.dtype, jnp.floating),
+        TypeError,
+        "integration limits must be real floating point, got dtype "
+        f"{interval.dtype}. Complex limits are not supported: the subdivision has to "
+        "order the breakpoints, which complex numbers do not admit.",
+    )
     a, b = interval[0], interval[-1]
-    sgn = (-1) ** (a > b)
+    # An `xtype` scalar rather than the integer `(-1) ** (a > b)`, so that it cannot
+    # participate in promotion downstream.
+    sgn = jnp.where(a > b, -1, 1).astype(interval.dtype)
     a, b = jnp.minimum(a, b), jnp.maximum(a, b)
     # catch breakpoints that are outside the domain, replace with endpoints
     # this creates intervals of 0 length which will be ignored later
@@ -143,6 +225,37 @@ class _MappedFunction(eqx.Module):
         return self.sgn * w * self.fun(x, *args)
 
 
+def tanhsinh_tmax(dtype) -> float:
+    """Largest ``t`` whose tanh-sinh node is still distinct from the endpoint.
+
+    The tanh-sinh nodes ``x = tanh(pi/2 sinh(t))`` cluster double-exponentially at the
+    endpoints, which is what lets the rule handle an endpoint singularity. A node is
+    only useful while it stays distinguishable from the endpoint, so ``t`` is cut off at
+    ``x = 1 - 10*eps``. That bound, and with it how close to the singularity the rule
+    can look, is set by the precision the nodes will be *used* at -- which is why this
+    takes a dtype rather than being a constant.
+
+    Warns when the precision is coarse enough that the clustering has essentially been
+    lost. Computed in float64 on the host; the result is a compile time constant.
+    """
+    eps = float(jnp.finfo(dtype).eps)
+    closest = 10 * eps
+    if closest > 1e-3:
+        warnings.warn(
+            f"tanh-sinh quadrature in {jnp.dtype(dtype).name} can place a node no "
+            f"closer than {closest:.1e} of the half width from an endpoint (float64 "
+            "reaches 2.2e-15), so the double exponential clustering that makes the "
+            "method good at endpoint singularities is largely gone. Results are still "
+            "valid but no better than a plain trapezoidal rule near the endpoints; use "
+            "float32 or better, or use quadgk/quadcc instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+    tanhinv = lambda x: 0.5 * np.log((1 + x) / (1 - x))
+    sinhinv = lambda x: np.log(x + np.sqrt(x**2 + 1))
+    return float(sinhinv(2 / np.pi * tanhinv(1.0 - closest)))
+
+
 def tanhsinh_transform(fun, interval):
     """Transform a function by mapping with tanh-sinh.
 
@@ -168,6 +281,7 @@ def tanhsinh_transform(fun, interval):
         NotImplementedError,
         "tanh-sinh transformation with breakpoints not supported",
     )
+    xtype = jnp.asarray(interval).dtype
     # map a, b -> [-1, 1]
     fun, interval = map_interval(fun, interval)
 
@@ -176,16 +290,10 @@ def tanhsinh_transform(fun, interval):
     # we generally only need to integrate ~[-3, 3] or ~[-4, 4]
     # we don't want to include the endpoint that maps to x==1 to avoid
     # possible singularities, so we find the largest t s.t. x(t) < 1
-    # and use that as our interval
-    def get_tmax(xmax):
-        """Inverse of tanh-sinh transform."""
-        tanhinv = lambda x: 1 / 2 * jnp.log((1 + x) / (1 - x))
-        sinhinv = lambda x: jnp.log(x + jnp.sqrt(x**2 + 1))
-        return sinhinv(2 / jnp.pi * tanhinv(xmax))
-
-    # inverse of tanh-sinh transformation for x = 1-eps
-    tmax = get_tmax(jnp.array(1.0) - 10 * jnp.finfo(jnp.array(1.0)).eps)
-    interval_t = jnp.array([-tmax, tmax])
+    # and use that as our interval. How large that is depends on the precision the
+    # abscissae are carried at, so it follows `interval`.
+    tmax = tanhsinh_tmax(xtype)
+    interval_t = jnp.array([-tmax, tmax], dtype=xtype)
     return func, interval_t
 
 
@@ -253,9 +361,13 @@ def _decode_status(status):
 STATUS = {i: _decode_status(i) for i in range(int(2**5))}
 
 
-def wrap_func(fun: Callable[..., jax.Array], args: tuple[Any, ...]):
-    """Vectorize, jit, and mask out inf/nan."""
-    f = jax.eval_shape(fun, jnp.array(0.0), *args)
+def wrap_func(fun: Callable[..., jax.Array], args: tuple[Any, ...], xtype):
+    """Vectorize, jit, and mask out inf/nan.
+
+    ``xtype`` is the dtype the integrand will be called at, and the integrand is probed
+    at that dtype rather than at a weakly typed default. See the note on ``MAPFUNS``.
+    """
+    f = jax.eval_shape(fun, jnp.zeros((), xtype), *args)
     # need to make sure we get the correct shape for array valued integrands
     outsig = "(" + ",".join("n" + str(i) for i in range(len(f.shape))) + ")"
 
@@ -333,10 +445,6 @@ def bounded_while_loop(condfun, bodyfun, init_val, bound):
         return jax.lax.cond(unvmap_any(keep), stepfun, lambda x: x, state), None
 
     return jax.lax.scan(scanfun, init_val, None, bound)[0]
-
-
-def _get_eps(x: jax.Array) -> jax.Array:
-    return jnp.finfo(x.dtype).eps  # pyright: ignore
 
 
 def _pnorm(x: jax.Array, p: int | float | jax.Array) -> jax.Array:

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,5 +1,10 @@
 """Tests for adaptive quadrature routines."""
 
+import os
+import subprocess
+import sys
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -9,7 +14,9 @@ from jax import config
 
 import quadax
 from quadax import (
+    ClenshawCurtisRule,
     GaussKronrodRule,
+    TanhSinhRule,
     adaptive_quadrature,
     quadcc,
     quadgk,
@@ -897,3 +904,313 @@ class TestErrors:
         """Only the tabulated Gauss-Kronrod orders are available."""
         with pytest.raises(NotImplementedError, match="not implemented"):
             GaussKronrodRule(order=7)
+
+
+# The dtype of `interval` is the statement of what precision the user wants. The tests
+# below pin the four dtypes described by `quadax.utils.DTypes`: the abscissa the
+# integrand is called with, the integrand values and returned integral, the error
+# estimate, and the default tolerances.
+
+adaptive_methods = [quadgk, quadcc, quadts]
+all_methods = adaptive_methods + [romberg, rombergts]
+rules = [GaussKronrodRule, ClenshawCurtisRule, TanhSinhRule]
+
+real_dtypes = [jnp.float64, jnp.float32, jnp.float16, jnp.bfloat16]
+complex_dtypes = [jnp.complex128, jnp.complex64]
+# `interval` is always real; complex is a property of the integrand's values.
+real_of = {jnp.complex128: jnp.float64, jnp.complex64: jnp.float32}
+
+# How much worse than sqrt(eps) a converged result is allowed to be. Generous, because
+# the point of these tests is dtype plumbing, not accuracy.
+_SLOP = 50
+
+
+@pytest.fixture
+def quiet_tanhsinh():
+    """Let the half precision tanh-sinh warning through without failing the test.
+
+    ``pyproject.toml`` turns warnings into errors, which is right for the rest of the
+    suite. The warning itself is asserted on separately in ``TestTanhSinhPrecision``.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*tanh-sinh quadrature in.*")
+        yield
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+class TestWorkingDType:
+    """The dtype of ``interval`` selects the precision, and is respected end to end."""
+
+    @pytest.mark.parametrize("method", all_methods)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_round_trip(self, method, dtype):
+        """Y and err come back at the requested precision, and the answer is right."""
+        interval = jnp.array([0.0, 1.0], dtype=dtype)
+        y, info = method(lambda x: jnp.exp(-x), interval)
+
+        assert y.dtype == dtype
+        assert jnp.asarray(info.err).dtype == dtype
+        # exp(-x) on [0, 1]; only asking for sqrt(eps)-ish accuracy
+        tol = _SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+        np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=tol)
+
+    @pytest.mark.parametrize("method", all_methods)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_integrand_is_called_at_the_requested_dtype(self, method, dtype):
+        """The integrand sees ``x`` at the interval's dtype, not the default one.
+
+        A node table stored at float64 would hand the user's function a float64 ``x``
+        whatever precision it asked for. The assert runs at trace time.
+        """
+        seen = []
+
+        def fun(x):
+            seen.append(x.dtype)
+            return jnp.exp(-x)
+
+        method(fun, jnp.array([0.0, 1.0], dtype=dtype))
+        assert seen, "integrand was never traced"
+        assert set(seen) == {jnp.dtype(dtype)}, f"integrand saw {set(seen)}"
+
+    @pytest.mark.parametrize("method", all_methods)
+    def test_integrand_may_upcast(self, method):
+        """An integrand that deliberately upcasts is respected.
+
+        The abscissa stays at the precision that was asked for, but the accumulation and
+        the result follow the integrand.
+        """
+        seen = []
+
+        def fun(x):
+            seen.append(x.dtype)
+            return jnp.exp(-x.astype(jnp.float64))
+
+        y, info = method(fun, jnp.array([0.0, 1.0], dtype=jnp.float32))
+        assert set(seen) == {jnp.dtype(jnp.float32)}
+        assert y.dtype == jnp.float64
+        assert jnp.asarray(info.err).dtype == jnp.float64
+
+    @pytest.mark.parametrize("method", all_methods)
+    @pytest.mark.parametrize("dtype", complex_dtypes)
+    def test_complex_integrand(self, method, dtype):
+        """Complex values, real limits: the error estimate stays real."""
+        rtype = real_of[dtype]
+        interval = jnp.array([0.0, 1.0], dtype=rtype)
+        fun = lambda x: (jnp.exp(-x) + 1j * jnp.sin(x)).astype(dtype)
+        y, info = method(fun, interval)
+
+        assert y.dtype == dtype
+        assert jnp.asarray(info.err).dtype == rtype
+        tol = _SLOP * np.sqrt(float(jnp.finfo(rtype).eps))
+        np.testing.assert_allclose(complex(y).real, 1 - np.exp(-1), atol=tol)
+        np.testing.assert_allclose(complex(y).imag, 1 - np.cos(1), atol=tol)
+
+    @pytest.mark.parametrize("method", all_methods)
+    def test_complex_limits_rejected(self, method):
+        """Complex limits have no ordering, so the subdivision cannot be defined."""
+        with pytest.raises(TypeError, match="real floating point"):
+            method(lambda x: x, jnp.array([0.0 + 0j, 1.0 + 0j]))
+
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_infinite_limits(self, dtype):
+        """All four branches of the interval map agree on a dtype.
+
+        The integrand is probed to determine the output dtype; if that probe is done
+        with a weakly typed scalar the four branches can settle on different dtypes and
+        the ``switch`` between them fails to build.
+        """
+        tol = _SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+        for interval, expected in [
+            ([0.0, jnp.inf], np.sqrt(np.pi) / 2),
+            ([-jnp.inf, 0.0], np.sqrt(np.pi) / 2),
+            ([-jnp.inf, jnp.inf], np.sqrt(np.pi)),
+        ]:
+            y, _ = quadgk(lambda x: jnp.exp(-(x**2)), jnp.array(interval, dtype=dtype))
+            assert y.dtype == dtype
+            np.testing.assert_allclose(float(y), expected, atol=10 * tol, rtol=10 * tol)
+
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_breakpoints_and_vector_valued(self, dtype):
+        """Breakpoints keep the mesh at the abscissa dtype for a vector integrand."""
+        interval = jnp.array([0.0, 0.5, 1.0], dtype=dtype)
+        y, info = quadgk(lambda x: jnp.array([jnp.exp(-x), x**2]), interval)
+        assert y.dtype == dtype
+        assert jnp.asarray(info.err).dtype == dtype
+        tol = _SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+        np.testing.assert_allclose(np.asarray(y), [1 - np.exp(-1), 1 / 3], atol=tol)
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+class TestFixedOrderRuleDTypes:
+    """The fixed order rules are a public entry point in their own right."""
+
+    @pytest.mark.parametrize("rule", rules)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_integrate(self, rule, dtype):
+        """All four outputs of ``integrate`` come back at the abscissa dtype."""
+        a, b = jnp.array(0.0, dtype), jnp.array(1.0, dtype)
+        y, err, y_abs, y_mmn = rule().integrate(lambda x: jnp.exp(-x), a, b, ())
+        assert y.dtype == dtype
+        assert err.dtype == y_abs.dtype == y_mmn.dtype == dtype
+        tol = _SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+        np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=tol)
+
+    @pytest.mark.parametrize("rule", rules)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_degenerate_interval(self, rule, dtype):
+        """``a == b`` takes the other branch of a ``cond``, which has to agree.
+
+        Both branches are built for any integrand dtype, so the zero branch must be
+        constructed at the same dtype the weights promote the real branch to.
+        """
+        a = jnp.array(0.5, dtype)
+        out = rule().integrate(lambda x: jnp.exp(-x), a, a, ())
+        for v in out:
+            assert v.dtype == dtype
+            np.testing.assert_array_equal(np.asarray(v), 0.0)
+
+    @pytest.mark.parametrize("rule", rules)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_apply(self, rule, dtype):
+        """The low level ``_apply`` keeps the dtype too."""
+        a, b = jnp.array(0.0, dtype), jnp.array(1.0, dtype)
+        y = rule()._apply(lambda x: jnp.exp(-x), a, b, ())
+        assert y.dtype == dtype
+
+    @pytest.mark.parametrize("rule", rules)
+    def test_weights_sum_to_two(self, rule):
+        """Both the high and low order rules integrate 1 over [-1, 1] exactly."""
+        r = rule()
+        np.testing.assert_allclose(float(jnp.sum(r._wh)), 2.0, atol=1e-14)
+        np.testing.assert_allclose(float(jnp.sum(r._wl)), 2.0, atol=1e-14)
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+class TestErrorEstimateDTypes:
+    """The reported error must never under-estimate, at any precision."""
+
+    @pytest.mark.parametrize("method", adaptive_methods)
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    @pytest.mark.parametrize(
+        "fun, exact",
+        [
+            (lambda x: jnp.exp(-(x**2)), 0.7468241328124271),
+            (lambda x: x**4 - 2 * x + 1, 1 / 5 - 1 + 1),
+        ],
+    )
+    def test_error_is_an_upper_bound(self, method, dtype, fun, exact):
+        """Reported error bounds the true error.
+
+        At float16/bfloat16 this is the only thing worth asserting: the roundoff floor
+        forces the QUADPACK estimator into its saturated regime, where it reports the
+        total variation of the integrand rather than a sharp estimate. Conservative, but
+        valid, which is what this pins.
+        """
+        y, info = method(fun, jnp.array([0.0, 1.0], dtype=dtype))
+        true_err = abs(float(y) - exact)
+        reported = float(jnp.asarray(info.err))
+        assert reported >= true_err, (
+            f"{jnp.dtype(dtype).name}: reported {reported:.3e} < true {true_err:.3e}"
+        )
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+class TestToleranceDTypes:
+    """Default tolerances follow the working dtype."""
+
+    @pytest.mark.parametrize("method", all_methods)
+    @pytest.mark.parametrize("dtype", [jnp.float64, jnp.float32])
+    def test_default_tolerance_tracks_dtype(self, method, dtype):
+        """With no tolerance given, accuracy lands near sqrt(eps) of the dtype."""
+        y, _ = method(lambda x: jnp.exp(-x), jnp.array([0.0, 1.0], dtype=dtype))
+        err = abs(float(y) - (1 - np.exp(-1)))
+        assert err <= _SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_explicit_tolerances_do_not_promote(self, dtype):
+        """A python float tolerance must not drag the working dtype up with it."""
+        y, info = quadgk(
+            lambda x: jnp.exp(-x),
+            jnp.array([0.0, 1.0], dtype=dtype),
+            epsabs=1e-3,
+            epsrel=1e-3,
+        )
+        assert y.dtype == dtype
+        assert jnp.asarray(info.err).dtype == dtype
+
+
+class TestTanhSinhPrecision:
+    """Half precision costs the tanh-sinh rules their double exponential clustering."""
+
+    @pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+    @pytest.mark.parametrize("method", [quadts, rombergts])
+    def test_warns_in_half_precision(self, dtype, method):
+        """The user is told when the rule cannot deliver what it usually does."""
+        with pytest.warns(UserWarning, match="tanh-sinh quadrature in"):
+            method(lambda x: jnp.exp(-x), jnp.array([0.0, 1.0], dtype=dtype))
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    @pytest.mark.parametrize("method", [quadts, rombergts])
+    def test_silent_at_float32_and_above(self, dtype, method):
+        """No warning where the clustering is fine."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            method(lambda x: jnp.exp(-x), jnp.array([0.0, 1.0], dtype=dtype))
+
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_quadgk_never_warns(self, dtype):
+        """The warning belongs to the tanh-sinh rules, not to quadrature generally."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            quadgk(lambda x: jnp.exp(-x), jnp.array([0.0, 1.0], dtype=dtype))
+
+    @pytest.mark.usefixtures("quiet_tanhsinh")
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_nodes_stay_inside_the_interval(self, dtype):
+        """Rebuilt rather than cast, so no node collapses onto the endpoint.
+
+        Casting a float64 table down to bfloat16 would round the outer nodes to exactly
+        +/-1, silently dropping the effective order. Rebuilding at the target dtype
+        spreads the same number of nodes over the range that dtype can resolve.
+        """
+        xh, _, _ = TanhSinhRule(order=61)._nodes_weights(dtype)
+        assert xh.dtype == dtype
+        assert len(np.unique(np.asarray(xh, dtype=np.float64))) == len(xh)
+        assert np.all(np.abs(np.asarray(xh, dtype=np.float64)) < 1.0)
+
+
+def test_x64_disabled():
+    """Everything works, and stays float32, with x64 off.
+
+    A subprocess because ``jax_enable_x64`` is process global and the rest of the suite
+    asserts to float64 precision.
+    """
+    script = """
+import jax.numpy as jnp
+import numpy as np
+from quadax import quadgk, quadcc, quadts, romberg, rombergts
+
+for method in [quadgk, quadcc, quadts, romberg, rombergts]:
+    seen = []
+    def fun(x):
+        seen.append(x.dtype)
+        return jnp.exp(-x)
+    y, info = method(fun, jnp.array([0.0, 1.0]))
+    assert y.dtype == jnp.float32, (method.__name__, y.dtype)
+    assert info.err.dtype == jnp.float32, (method.__name__, info.err.dtype)
+    assert set(seen) == {jnp.dtype(jnp.float32)}, (method.__name__, set(seen))
+    np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=1e-4)
+
+# the default tolerance is sqrt(eps32) here, as it always has been
+y_d, i_d = quadgk(jnp.sin, jnp.array([0.0, 1.0]))
+tol = float(np.sqrt(np.finfo(np.float32).eps))
+y_e, i_e = quadgk(jnp.sin, jnp.array([0.0, 1.0]), epsabs=tol, epsrel=tol)
+np.testing.assert_array_equal(np.asarray(y_d), np.asarray(y_e))
+print("ok")
+"""
+    env = {**os.environ, "JAX_ENABLE_X64": "0"}
+    out = subprocess.run(
+        [sys.executable, "-c", script], env=env, capture_output=True, text=True
+    )
+    assert out.returncode == 0, out.stderr
+    assert "ok" in out.stdout

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -608,3 +608,48 @@ def test_romberg_differentiates_the_extrapolation(quad):
     np.testing.assert_allclose(fwd, rev, rtol=ULP_RTOL, atol=ULP_ATOL)
     # and accurate to Romberg's standard, not the trapezoid rule's
     assert abs(float(fwd[0]) - exact) < 1e-9
+
+
+class TestDerivativeDTypes:
+    """Derivatives keep the working dtype set by ``interval``.
+
+    The dtype plumbing itself is covered in ``test_adaptive.py``; here it only has to
+    survive the adjoints.
+    """
+
+    # how much worse than sqrt(eps) a converged result is allowed to be, since these
+    # check dtype plumbing rather than accuracy
+    slop = 50
+
+    @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
+    @pytest.mark.parametrize("method", adaptive_methods)
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_grad_dtype(self, adjoint, method, dtype):
+        """Reverse mode returns a gradient at the interval's dtype, and correct."""
+
+        def total(c):
+            y, _ = method(
+                lambda x, c: jnp.exp(-c * x),
+                jnp.array([0.0, 1.0], dtype=dtype),
+                args=(c,),
+                adjoint=adjoint,
+            )
+            return y
+
+        c = jnp.array(1.0, dtype)
+        g = jax.grad(total)(c)
+        assert g.dtype == dtype
+        # d/dc int_0^1 exp(-c x) dx = (exp(-c)*(c+1) - 1)/c^2
+        expected = (np.exp(-1) * 2 - 1) / 1.0
+        np.testing.assert_allclose(
+            float(g), expected, rtol=self.slop * np.sqrt(float(jnp.finfo(dtype).eps))
+        )
+
+    @pytest.mark.parametrize("method", adaptive_methods)
+    @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+    def test_jvp_dtype(self, method, dtype):
+        """Forward mode keeps both the primal and the tangent at that dtype."""
+        f = lambda a: method(jnp.sin, jnp.array([0.0, 1.0], dtype=dtype) * a)[0]
+        y, y_dot = jax.jvp(f, (jnp.array(1.0, dtype),), (jnp.array(1.0, dtype),))
+        assert y.dtype == dtype
+        assert y_dot.dtype == dtype


### PR DESCRIPTION
- quadax now works in the precision you ask for, rather than always in whatever
  `jax_enable_x64` happens to make the default. The dtype of `interval` is how you ask:
  the integrand is called with an `x` of that dtype, and the result follows it unless
  the integrand upcasts internally, in which case that is respected too. `float16`,
  `bfloat16`, `float32`, `float64` and complex integrands are all supported, and the
  default `epsabs`/`epsrel` follow the working dtype. See "Precision and dtypes" in the
  documentation.
  - Fixes a `TypeError` from `map_interval` that made *any* explicitly-dtyped `interval`
    other than the default unusable, on all of `quadgk`, `quadcc`, `quadts`, `romberg`
    and `rombergts`, for finite and infinite intervals alike.
  - Fixes a `TypeError` from `GaussKronrodRule`/`ClenshawCurtisRule`/`TanhSinhRule`'s
    `integrate` when the integrand's dtype was not the JAX default.
  - The node and weight tables are now built in float64 on the host and rounded once to
    the working dtype. Previously the Clenshaw-Curtis and tanh-sinh tables were
    *computed* in float32 whenever x64 was off, which is less accurate. Building them
    with numpy also makes them independent of the backend's transcendental functions,
    which are not all as accurate as the host's; as a result `quadts` and `rombergts`
    results move in the last ulp or two. `quadgk` and `quadcc` are bit-identical.
  - `simpson` and `cumulative_simpson` no longer return the default float dtype
    regardless of their inputs.
  - No change for float64, or for any configuration that worked before: the default
    tolerances resolve to exactly what they used to in each case.
- `quadts` and `rombergts` now warn when used at `float16`/`bfloat16`, where the
  tanh-sinh clustering can no longer get close enough to an endpoint to be worth having.