### PR TITLE
Add option to batch integrand evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ v0.3.0
   - ``LeibnizAdjoint`` gives the derivative its own adaptive solve, so it gets its own
     error control rather than inheriting the subdivision chosen for the integral. Often
     several times faster for a gradient of a scalar-valued integral.
+- Added control over how many integrand evaluations are made in parallel.
+  - ``quadgk``, ``quadcc`` and ``quadts`` take a new ``batch_size``, as do the rule
+    classes ``GaussKronrodRule``, ``ClenshawCurtisRule`` and ``TanhSinhRule``. It bounds
+    how many of the local rule's nodes are evaluated at once, and is clipped at the
+    number of nodes. Lowering it bounds the memory an expensive integrand needs, which
+    previously could only be done by dropping the order and losing accuracy with it.
+  - ``romberg`` and ``rombergts`` take the same argument, where it instead raises the
+    width from one point at a time. A level places ``2**(k-1)`` new points, a count only
+    known at run time, so the last batch of a level is padded up to a full one and one
+    batch shape is traced for every level. ``batch_size=None`` remains the sequential
+    loop.
 - Fixed a bug in the sub-interval bookkeeping causing wrong results when the number of
   iterations reaches the max allowed (though in this case the solution is marked as
   un-converged anyways)
@@ -40,23 +51,23 @@ v0.3.0
   Some integrations that used to report ``status == 0`` while quietly missing the
   requested tolerance now report a non-zero status instead; the values they return are
   more accurate than before, not less.
-- ``status`` is no longer set on an iteration that reaches the requested tolerance. An
-  integration that converged just as it ran out of sub-intervals previously reported
-  ``MAX_NINTER`` despite having succeeded.
-- Integrands that are simply unresolved, rather than limited by roundoff, are no longer
-  written off as ``ROUNDOFF`` while they are still converging.
-- Asking for a tolerance tighter than the arithmetic can deliver is now reported as
-  ``ROUNDOFF``, rather than subdividing until the ``max_ninter`` limit is reached. Such
-  integrations also finish sooner.
-- The reported error estimate can no longer come back negative.
-- Documented when the nested-rule error estimate can under-state the true error: on
-  integrands sampled at fewer than about three points per oscillation (any rule, any
-  order), on endpoint singularities under ``ClenshawCurtisRule``, and for
-  ``TanhSinhRule`` below order 15. Behaviour is unchanged; this is guidance only.
-- ``y_abs`` and ``y_mmn`` returned by ``AbstractQuadratureRule.integrate`` are now the
-  integrals over ``[a, b]`` that their docstrings describe; they were previously scaled
-  by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or implementing
-  a custom one.
+  - ``status`` is no longer set on an iteration that reaches the requested tolerance. An
+    integration that converged just as it ran out of sub-intervals previously reported
+    ``MAX_NINTER`` despite having succeeded.
+  - Integrands that are simply unresolved, rather than limited by roundoff, are no
+    longer written off as ``ROUNDOFF`` while they are still converging.
+  - Asking for a tolerance tighter than the arithmetic can deliver is now reported as
+    ``ROUNDOFF``, rather than subdividing until the ``max_ninter`` limit is reached.
+    Such integrations also finish sooner.
+  - The reported error estimate can no longer come back negative.
+  - Documented when the nested-rule error estimate can under-state the true error: on
+    integrands sampled at fewer than about three points per oscillation (any rule, any
+    order), on endpoint singularities under ``ClenshawCurtisRule``, and for
+    ``TanhSinhRule`` below order 15. Behaviour is unchanged; this is guidance only.
+  - ``y_abs`` and ``y_mmn`` returned by ``AbstractQuadratureRule.integrate`` are now the
+    integrals over ``[a, b]`` that their docstrings describe; they were previously
+    scaled by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or
+    implementing a custom one.
 - **Breaking**: removed ``fixed_quadgk``, ``fixed_quadcc``, and ``fixed_quadts``,
   deprecated since v0.2.2. Use ``GaussKronrodRule``, ``ClenshawCurtisRule``, and
   ``TanhSinhRule`` instead, eg

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,6 +89,13 @@ is relative to the quadrature around it, how hard its derivative is to integrate
 compared to the integrand, and how many parameters are involved. Time both on your own
 problem before caring much about the difference.
 
+Both take two options controlling the memory a derivative needs. ``checkpoint`` (on by
+default) recomputes each block of sub-intervals during the backward pass instead of
+storing it, and is where nearly all of the saving is. ``chunk_size`` sets how many
+sub-intervals of the frozen subdivision are evaluated at once, and multiplies with the
+``batch_size`` of the routine itself: a gradient evaluates the integrand at up to
+``chunk_size * batch_size`` points at a time.
+
 
 Integrating function from sampled values
 ----------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,15 +84,28 @@ singularity. Use ``quadgk`` or ``quadcc`` there, or move to float32.
 
 Notes on parallel efficiency
 ============================
-Adaptive algorithms are inherently somewhat sequential, so perfect parallelism
-is generally not achievable. ``romberg`` and ``rombergts`` are fully sequential, due to
-limitiations on dynamically sized arrays in JAX. All of the ``quad*`` methods are parallelized
-on a local level (ie, for each sub-interval, the function evaluations are vectorized).
-This means that ``quad*`` methods will evaluate the integrand in batch sizes of ``order``,
-and hence higher order methods will tend to be more efficient on GPU/TPU. However, if the
-integrand is not sufficiently smooth, using a higher order method can slow down convergence,
-particularly for ``quadgk``, ``quadts`` and ``quadcc`` are somewhat less sensitive to the
-smoothness of the integrand.
+Adaptive algorithms are inherently somewhat sequential, so perfect parallelism is
+generally not achievable. What parallelism there is happens at a local level: for each
+sub-interval, the ``quad*`` methods can vectorize the integrand evaluation over all of
+the local rule's nodes, controlled via ``batch_size``. The default is to vectorize over
+all the local nodes at once, so higher order methods tend to be more efficient on
+GPU/TPU. However, if the integrand is not sufficiently smooth, a higher order method
+can be less efficient, but often still wins on wall time on accelerators.
+
+``romberg`` and ``rombergts`` are sequential by default. The number of new points a
+refinement level places is only known at run time, so there is no single shape for
+JAX to vectorize over. Setting ``batch_size`` will vectorize over the points on each
+level, but will pad the coarser levels, so the total number of function evaluations
+will slightly increase.
+
+In reverse mode there is a second axis to parallelize over, since the sub-intervals of
+the converged subdivision are independent. The adjoints evaluate them ``chunk_size`` at
+a time, set on the adjoint rather than on the routine::
+
+    quadgk(fun, interval, batch_size=8, adjoint=DirectAdjoint(chunk_size=4))
+
+The two multiply: a gradient evaluates the integrand at up to ``chunk_size`` times
+``batch_size`` points at once.
 
 
 

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -68,6 +68,7 @@ def quadgk(
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = True,
+    batch_size: int | None = None,
 ):
     """Global adaptive quadrature using Gauss-Kronrod rule.
 
@@ -125,6 +126,13 @@ def quadgk(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the local rule's nodes at once, which is fastest but makes peak memory
+        scale with the order. Lower it to reduce memory on an expensive integrand.
+        Values larger than the number of nodes are clipped to it. In a gradient the
+        adjoint evaluates several sub-intervals together, so the width there is
+        ``batch_size`` times the adjoint's own ``chunk_size``.
 
     Returns
     -------
@@ -157,12 +165,13 @@ def quadgk(
     Notes
     -----
     Adaptive algorithms are inherently somewhat sequential, so perfect parallelism
-    is generally not achievable. The local quadrature rule vmaps integrand evaluation at
-    ``order`` points, so using higher order methods will generally be more efficient on
-    GPU/TPU.
+    is generally not achievable. The local quadrature rule evaluates the integrand at
+    all of its nodes at once, so using higher order methods will generally be more
+    efficient on GPU/TPU. ``batch_size`` splits that evaluation up where the memory it
+    needs is the binding constraint instead.
 
     """
-    rule = GaussKronrodRule(order, norm)
+    rule = GaussKronrodRule(order, norm, batch_size)
     y, info = adaptive_quadrature(
         rule,
         fun,
@@ -175,7 +184,9 @@ def quadgk(
         adjoint=adjoint,
         extrapolate=extrapolate,
     )
-    info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
+    info = QuadratureInfo(
+        info.err, info.neval * rule.nodes_per_call, info.status, info.info
+    )
     return y, info
 
 
@@ -192,6 +203,7 @@ def quadcc(
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = True,
+    batch_size: int | None = None,
 ):
     """Global adaptive quadrature using Clenshaw-Curtis rule.
 
@@ -248,6 +260,13 @@ def quadcc(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the local rule's nodes at once, which is fastest but makes peak memory
+        scale with the order. Lower it to reduce memory on an expensive integrand.
+        Values larger than the number of nodes are clipped to it. In a gradient the
+        adjoint evaluates several sub-intervals together, so the width there is
+        ``batch_size`` times the adjoint's own ``chunk_size``.
 
     Returns
     -------
@@ -280,12 +299,13 @@ def quadcc(
     Notes
     -----
     Adaptive algorithms are inherently somewhat sequential, so perfect parallelism
-    is generally not achievable. The local quadrature rule vmaps integrand evaluation at
-    ``order`` points, so using higher order methods will generally be more efficient on
-    GPU/TPU.
+    is generally not achievable. The local quadrature rule evaluates the integrand at
+    all of its nodes at once, so using higher order methods will generally be more
+    efficient on GPU/TPU. ``batch_size`` splits that evaluation up where the memory it
+    needs is the binding constraint instead.
 
     """
-    rule = ClenshawCurtisRule(order, norm)
+    rule = ClenshawCurtisRule(order, norm, batch_size)
     y, info = adaptive_quadrature(
         rule,
         fun,
@@ -298,7 +318,9 @@ def quadcc(
         adjoint=adjoint,
         extrapolate=extrapolate,
     )
-    info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
+    info = QuadratureInfo(
+        info.err, info.neval * rule.nodes_per_call, info.status, info.info
+    )
     return y, info
 
 
@@ -315,6 +337,7 @@ def quadts(
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = False,
+    batch_size: int | None = None,
 ):
     """Global adaptive quadrature using trapezoidal tanh-sinh rule.
 
@@ -372,6 +395,13 @@ def quadts(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the local rule's nodes at once, which is fastest but makes peak memory
+        scale with the order. Lower it to reduce memory on an expensive integrand.
+        Values larger than the number of nodes are clipped to it. In a gradient the
+        adjoint evaluates several sub-intervals together, so the width there is
+        ``batch_size`` times the adjoint's own ``chunk_size``.
 
     Returns
     -------
@@ -404,12 +434,13 @@ def quadts(
     Notes
     -----
     Adaptive algorithms are inherently somewhat sequential, so perfect parallelism
-    is generally not achievable. The local quadrature rule vmaps integrand evaluation at
-    ``order`` points, so using higher order methods will generally be more efficient on
-    GPU/TPU.
+    is generally not achievable. The local quadrature rule evaluates the integrand at
+    all of its nodes at once, so using higher order methods will generally be more
+    efficient on GPU/TPU. ``batch_size`` splits that evaluation up where the memory it
+    needs is the binding constraint instead.
 
     """
-    rule = TanhSinhRule(order, norm)
+    rule = TanhSinhRule(order, norm, batch_size)
     y, info = adaptive_quadrature(
         rule,
         fun,
@@ -422,7 +453,9 @@ def quadts(
         adjoint=adjoint,
         extrapolate=extrapolate,
     )
-    info = QuadratureInfo(info.err, info.neval * order, info.status, info.info)
+    info = QuadratureInfo(
+        info.err, info.neval * rule.nodes_per_call, info.status, info.info
+    )
     return y, info
 
 

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -17,7 +17,7 @@ from jax.interpreters import ad, batching, mlir
 
 from . import _acceleration
 from .fixed_order import AbstractQuadratureRule
-from .utils import _real_dtype, map_interval, tree_where, wrap_func
+from .utils import _real_dtype, check_size, map_interval, tree_where, wrap_func
 
 
 class _ConvertedFunction(eqx.Module):
@@ -105,13 +105,18 @@ class QuadratureOps(NamedTuple):
     mesh_is_primal: bool = True
 
 
-def _with_checkpoint(ops, checkpoint):
-    """Thread the checkpointing choice down to the fixed-subdivision quadrature."""
+def _with_options(ops, checkpoint, chunk_size):
+    """Thread the adjoint's own options down to the fixed-subdivision quadrature.
+
+    Only the operations that evaluate a fixed subdivision take these; ``solve`` is the
+    primal adaptive loop and is unaffected by either.
+    """
+    opts = {"checkpoint": checkpoint, "chunk_size": chunk_size}
     upd = {}
     if ops.on_mesh is not None:
-        upd["on_mesh"] = partial(ops.on_mesh, checkpoint=checkpoint)
+        upd["on_mesh"] = partial(ops.on_mesh, **opts)
     if ops.rebuild is not None and ops.frozen_solve is not None:
-        upd["frozen_solve"] = partial(ops.frozen_solve, checkpoint=checkpoint)
+        upd["frozen_solve"] = partial(ops.frozen_solve, **opts)
     return ops._replace(**upd) if upd else ops
 
 
@@ -141,17 +146,19 @@ def _rebuild_mesh(interval, frozen):
     return lo + frac_a * width, lo + frac_b * width
 
 
-# How many sub-intervals of a fixed subdivision are evaluated at once. Evaluating all of
-# them together is fastest but makes peak memory scale with ``max_ninter``, which is a
-# safety bound users tend to set generously; evaluating one at a time streams but
-# serializes. Measured on a scalar integrand with an order 21 rule, 8 is where the curve
-# turns over: it matches one-at-a-time peak memory at large ``max_ninter`` while being
-# noticeably faster in reverse mode, and larger blocks buy little more speed for a lot
-# more memory.
+# Default for the adjoints' ``chunk_size``: how many sub-intervals of a fixed
+# subdivision are evaluated at once. Evaluating them all together is fastest but makes
+# peak memory scale with ``max_ninter``, which is a safety bound users tend to set
+# generously; evaluating one at a time streams but serializes. Measured on a scalar
+# integrand with an order 21 rule, 8 is where the curve turns over: it matches
+# one-at-a-time peak memory at large ``max_ninter`` while being noticeably faster in
+# reverse mode, and larger blocks buy little more speed for a lot more memory. That
+# measurement is for one shape of problem, which is why this is a default and not a
+# constant.
 _CHUNK = 8
 
 
-def _block_mesh(rule, vfunc, a_arr, b_arr):
+def _block_mesh(rule, vfunc, a_arr, b_arr, chunk_size):
     """Group a fixed subdivision into blocks of sub-intervals ready for evaluation.
 
     Returns the blocked endpoints and mask to scan over, a function evaluating one
@@ -179,13 +186,13 @@ def _block_mesh(rule, vfunc, a_arr, b_arr):
     # cannot be transposed. Substituting a real sub-interval also stops an integrand
     # that is singular somewhere in the mapped domain from poisoning the unused slots
     # with a NaN that the mask would then propagate. So the granularity of the skip is
-    # ``_CHUNK``.
+    # ``chunk_size``.
     used = a_arr != b_arr
     a_safe = jnp.where(used, a_arr, a_arr[0])
     b_safe = jnp.where(used, b_arr, b_arr[0])
 
     nslot = a_arr.shape[0]
-    chunk = min(_CHUNK, nslot)
+    chunk = min(chunk_size, nslot)
     pad = -nslot % chunk
     reshape = lambda x, fill: jnp.pad(x, (0, pad), constant_values=fill).reshape(
         -1, chunk
@@ -233,10 +240,12 @@ def _checkpointed(bodyfun, checkpoint):
     return jax.checkpoint(bodyfun) if checkpoint else bodyfun
 
 
-def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
+def _quad_on_mesh(
+    rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True, chunk_size=_CHUNK
+):
     """Apply the local rule on a fixed subdivision and sum the contributions."""
     del kwargs
-    blocks, evaluate, sds, _ = _block_mesh(rule, vfunc, a_arr, b_arr)
+    blocks, evaluate, sds, _ = _block_mesh(rule, vfunc, a_arr, b_arr, chunk_size)
 
     def bodyfun(total, block):
         return total + jnp.sum(evaluate(block), axis=0), None
@@ -247,14 +256,16 @@ def _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
     return total
 
 
-def _values_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True):
+def _values_on_mesh(
+    rule, vfunc, a_arr, b_arr, kwargs, *, checkpoint=True, chunk_size=_CHUNK
+):
     """Apply the local rule on a fixed subdivision, keeping the contributions separate.
 
     As ``_quad_on_mesh``, except that the per-sub-interval values are returned rather
     than summed, because the replay has to recombine them in more than one way.
     """
     del kwargs
-    blocks, evaluate, sds, nslot = _block_mesh(rule, vfunc, a_arr, b_arr)
+    blocks, evaluate, sds, nslot = _block_mesh(rule, vfunc, a_arr, b_arr, chunk_size)
 
     def bodyfun(carry, block):
         return carry, evaluate(block)
@@ -268,10 +279,14 @@ def _frozen_mesh(state):
     return (state["owner"], state["frac_a"], state["frac_b"])
 
 
-def _mesh_solve(rule, vfunc, interval, frozen, kwargs, *, checkpoint=True):
+def _mesh_solve(
+    rule, vfunc, interval, frozen, kwargs, *, checkpoint=True, chunk_size=_CHUNK
+):
     """Quadrature on the subdivision implied by `frozen`, as a function of interval."""
     a_arr, b_arr = _rebuild_mesh(interval, frozen)
-    return _quad_on_mesh(rule, vfunc, a_arr, b_arr, kwargs, checkpoint=checkpoint)
+    return _quad_on_mesh(
+        rule, vfunc, a_arr, b_arr, kwargs, checkpoint=checkpoint, chunk_size=chunk_size
+    )
 
 
 class _ReplayRecord(NamedTuple):
@@ -317,7 +332,9 @@ def _frozen_replay(state):
     return _ReplayRecord(**{name: state[name] for name in _ReplayRecord._fields})
 
 
-def _replay_solve(rule, vfunc, interval, frozen, kwargs, *, checkpoint=True):
+def _replay_solve(
+    rule, vfunc, interval, frozen, kwargs, *, checkpoint=True, chunk_size=_CHUNK
+):
     """Re-run an accelerated quadrature on the decisions the primal settled on.
 
     An accelerated solve may return an extrapolated value rather than the sum over the
@@ -347,6 +364,7 @@ def _replay_solve(rule, vfunc, interval, frozen, kwargs, *, checkpoint=True):
         jnp.concatenate([mesh[1], parents[1]]),
         kwargs,
         checkpoint=checkpoint,
+        chunk_size=chunk_size,
     )
     nslot = mesh[0].shape[0]
     v_mesh, v_parent = values[:nslot], values[nslot:]
@@ -529,14 +547,26 @@ class DirectAdjoint(AbstractAdjoint):
         default. Turning it off has not been found to pay for itself even on integrands
         costing megaflops per evaluation, so treat it mainly as a diagnostic knob. No
         effect in forward mode.
+    chunk_size : int
+        How many sub-intervals of the frozen subdivision to evaluate at once: ``vmap``
+        within a chunk, ``scan`` across chunks. Trades peak memory against speed, and is
+        the reverse-mode counterpart of the quadrature routines' ``batch_size``, which
+        bounds the work *within* one sub-interval. The two multiply, so a gradient
+        evaluates the integrand at up to ``chunk_size`` times ``batch_size`` points at a
+        time. Lower it when a derivative runs out of memory and ``checkpoint`` was not
+        enough; raise it when the subdivision is small and the scan is pure overhead.
 
     """
 
     checkpoint: bool = True
+    chunk_size: int = _CHUNK
+
+    def __post_init__(self):
+        check_size(self.chunk_size, "chunk_size")
 
     def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
         """Evaluate the quadrature and differentiate it on the converged subdivision."""
-        ops = _with_checkpoint(ops, self.checkpoint)
+        ops = _with_options(ops, self.checkpoint, self.chunk_size)
         if ops.rebuild is None:
             if ops.frozen_solve is not None:
                 # No subdivision, but a discretization we can freeze (Romberg). Route
@@ -892,13 +922,29 @@ class LeibnizAdjoint(AbstractAdjoint):
         default. Turning it off has not been found to pay for itself even on integrands
         costing megaflops per evaluation, so treat it mainly as a diagnostic knob. No
         effect in forward mode.
+    chunk_size : int
+        How many sub-intervals of the frozen subdivision to evaluate at once: ``vmap``
+        within a chunk, ``scan`` across chunks. Trades peak memory against speed, and is
+        the reverse-mode counterpart of the quadrature routines' ``batch_size``, which
+        bounds the work *within* one sub-interval. The two multiply, so a gradient
+        evaluates the integrand at up to ``chunk_size`` times ``batch_size`` points at a
+        time. Lower it when a derivative runs out of memory and ``checkpoint`` was not
+        enough; raise it when the subdivision is small and the scan is pure overhead.
+
+        Only derivatives with respect to the interval of integration is taken on a
+        frozen subdivision here, so this has less effect than it does for
+        :class:`DirectAdjoint`.
     """
 
     checkpoint: bool = True
+    chunk_size: int = _CHUNK
+
+    def __post_init__(self):
+        check_size(self.chunk_size, "chunk_size")
 
     def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
         """Evaluate the quadrature, differentiating it by the Leibniz rule."""
-        ops = _with_checkpoint(ops, self.checkpoint)
+        ops = _with_options(ops, self.checkpoint, self.chunk_size)
         return _leibniz(
             rule, interval, args, consts, epsabs, epsrel, kwargs, ops=ops, freeze=False
         )

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 
 from .quad_weights import get_cc_table, get_tanhsinh_table, gk_weights
-from .utils import _real_dtype, tanhsinh_tmax, wrap_func
+from .utils import _real_dtype, check_size, tanhsinh_tmax, wrap_func
 
 
 def _dot(w, f):
@@ -127,6 +127,17 @@ class NestedRule(AbstractQuadratureRule):
     _wh: jax.Array
     _wl: jax.Array
     _norm: float | int | Callable
+    _batch_size: int | None
+
+    @property
+    def nodes_per_call(self) -> int:
+        """How many evaluations of the integrand one application of the rule costs.
+
+        Simply the number of nodes: ``batch_size`` changes how they are grouped, never
+        how many there are. Note this is the node count and not ``order``, which are not
+        always the same: an order ``n`` Clenshaw-Curtis rule has ``n + 1`` nodes.
+        """
+        return len(self._xh)
 
     def _nodes_weights(self, xtype) -> tuple[jax.Array, jax.Array, jax.Array]:
         """Nodes and weights of the rule for use at abscissa dtype ``xtype``.
@@ -178,7 +189,7 @@ class NestedRule(AbstractQuadratureRule):
         # The dtype of the limits is the statement of what precision was asked for: the
         # abscissae, and so the `x` the user's integrand sees, follow it.
         xtype = jnp.result_type(a, b)
-        vfun = wrap_func(fun, args, xtype)
+        vfun = wrap_func(fun, args, xtype, self._batch_size)
         xh, wh_table, wl_table = self._nodes_weights(xtype)
 
         def falsefun():
@@ -305,7 +316,7 @@ class NestedRule(AbstractQuadratureRule):
         auxiliary sums that ``integrate`` needs for its error estimate.
         """
         xtype = jnp.result_type(a, b)
-        vfun = wrap_func(fun, args, xtype)
+        vfun = wrap_func(fun, args, xtype, self._batch_size)
         xh, wh_table, _ = self._nodes_weights(xtype)
         halflength = (b - a) / 2
         center = (b + a) / 2
@@ -334,9 +345,21 @@ class GaussKronrodRule(NestedRule):
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the rule's nodes at once, which is fastest but makes peak memory scale
+        with the order. Values above the number of nodes are clipped to it. A value that
+        does not divide the number of nodes leaves a remainder, which is evaluated
+        together in one smaller batch, so the integrand is traced twice but never
+        evaluated at more points than the rule has nodes.
     """
 
-    def __init__(self, order: int = 21, norm: Callable | float | int = jnp.inf):
+    def __init__(
+        self,
+        order: int = 21,
+        norm: Callable | float | int = jnp.inf,
+        batch_size: int | None = None,
+    ):
         self._norm = norm
 
         try:
@@ -349,6 +372,10 @@ class GaussKronrodRule(NestedRule):
             raise NotImplementedError(
                 f"order {order} not implemented, should be one of {gk_weights.keys()}"
             ) from e
+        check_size(batch_size)
+        self._batch_size = (
+            None if batch_size is None else min(batch_size, len(self._xh))
+        )
 
 
 class ClenshawCurtisRule(NestedRule):
@@ -365,6 +392,13 @@ class ClenshawCurtisRule(NestedRule):
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the rule's nodes at once, which is fastest but makes peak memory scale
+        with the order. Values above the number of nodes are clipped to it. A value that
+        does not divide the number of nodes leaves a remainder, which is evaluated
+        together in one smaller batch, so the integrand is traced twice but never
+        evaluated at more points than the rule has nodes.
 
     Notes
     -----
@@ -374,11 +408,20 @@ class ClenshawCurtisRule(NestedRule):
     then report success while missing the requested tolerance.
     """
 
-    def __init__(self, order: int = 32, norm: Callable | float | int = jnp.inf):
+    def __init__(
+        self,
+        order: int = 32,
+        norm: Callable | float | int = jnp.inf,
+        batch_size: int | None = None,
+    ):
         self._norm = norm
         order = 2 * (order // 2)  # make sure its even
         xh, wh, wl = get_cc_table(order)
         self._xh, self._wh, self._wl = jnp.asarray(xh), jnp.asarray(wh), jnp.asarray(wl)
+        check_size(batch_size)
+        self._batch_size = (
+            None if batch_size is None else min(batch_size, len(self._xh))
+        )
 
 
 class TanhSinhRule(NestedRule):
@@ -395,6 +438,13 @@ class TanhSinhRule(NestedRule):
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
         should be callable.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is all of the rule's nodes at once, which is fastest but makes peak memory scale
+        with the order. Values above the number of nodes are clipped to it. A value that
+        does not divide the number of nodes leaves a remainder, which is evaluated
+        together in one smaller batch, so the integrand is traced twice but never
+        evaluated at more points than the rule has nodes.
 
     Notes
     -----
@@ -406,7 +456,12 @@ class TanhSinhRule(NestedRule):
 
     _order: int
 
-    def __init__(self, order: int = 61, norm: Callable | float | int = jnp.inf):
+    def __init__(
+        self,
+        order: int = 61,
+        norm: Callable | float | int = jnp.inf,
+        batch_size: int | None = None,
+    ):
         self._norm = norm
         self._order = 2 * (order // 2) + 1  # make sure its odd
         # The stored table is the one for the default dtype; `_nodes_weights` rebuilds
@@ -415,6 +470,10 @@ class TanhSinhRule(NestedRule):
             self._order, tanhsinh_tmax(jnp.result_type(float), self._order)
         )
         self._xh, self._wh, self._wl = jnp.asarray(xh), jnp.asarray(wh), jnp.asarray(wl)
+        check_size(batch_size)
+        self._batch_size = (
+            None if batch_size is None else min(batch_size, len(self._xh))
+        )
 
     def _nodes_weights(self, xtype) -> tuple[jax.Array, jax.Array, jax.Array]:
         """Rebuild the table at ``xtype`` rather than casting the stored one.

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -21,6 +21,7 @@ from .utils import (
     _pnorm,
     _real_dtype,
     bounded_while_loop,
+    check_size,
     errorif,
     map_interval,
     resolve_dtypes,
@@ -41,6 +42,7 @@ def romberg(
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
+    batch_size: int | None = None,
 ):
     """Romberg integration of a callable function or method.
 
@@ -95,6 +97,15 @@ def romberg(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is one at a time. Each refinement level doubles the number of new points, so
+        raising this is usually worth a lot on GPU/TPU, at the cost of peak memory
+        scaling with it. Levels with fewer new points than one batch are padded up to a
+        full batch, so the early levels of a run cost ``batch_size`` evaluations each
+        however few points they place; that padding is what keeps a single batch shape
+        traced for every level rather than one per level. Clipped to the largest level
+        ``divmax`` allows.
 
     Returns
     -------
@@ -117,9 +128,10 @@ def romberg(
 
     Notes
     -----
-    Due to limitations on dynamically sized arrays in JAX, this algorithm is fully
-    sequential and does not vectorize integrand evaluations, so may not be the most
-    efficient on GPU/TPU.
+    The number of new points a refinement level places is only known at run time, so
+    there is no single shape to vectorize over. Integrand evaluations are made in
+    fixed size batches of ``batch_size``, defaulting to one at a time; raise it to get
+    parallelism on GPU/TPU.
 
     """
     interval = jnp.atleast_1d(jnp.asarray(interval))
@@ -139,6 +151,10 @@ def romberg(
         epsrel = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
     epsabs = jnp.asarray(epsabs, dtypes.etype)
     epsrel = jnp.asarray(epsrel, dtypes.etype)
+    check_size(batch_size)
+    # No level ever places more than `2**(divmax - 1)` new points, so a larger batch
+    # would only ever be padding.
+    batch_size = min(batch_size or 1, 2 ** max(divmax - 1, 0))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -157,6 +173,7 @@ def romberg(
         build_integrand,
         dtypes.xtype,
         extrapolate,
+        batch_size,
     )
 
 
@@ -173,6 +190,7 @@ def _romberg(
     build,
     xtype,
     extrapolate,
+    batch_size,
 ):
     """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
     # Closure conversion has to happen on the user's function, before any wrapping:
@@ -184,7 +202,11 @@ def _romberg(
     ops = QuadratureOps(
         build=partial(build, f_conv=f_conv),
         solve=partial(
-            _romberg_solve, divmax=divmax, _norm=_norm, extrapolate=extrapolate
+            _romberg_solve,
+            divmax=divmax,
+            _norm=_norm,
+            extrapolate=extrapolate,
+            batch_size=batch_size,
         ),
         # Romberg has no subdivision to reuse, but it does settle on a number of
         # Richardson levels. Freezing that makes the result a fixed linear functional of
@@ -193,7 +215,12 @@ def _romberg(
         # differentiated directly, because evaluating it still involves a fori_loop with
         # dynamic bounds that JAX cannot reverse differentiate.
         frozen=lambda state: state["n"],
-        frozen_solve=partial(_romberg_levels, divmax=divmax, extrapolate=extrapolate),
+        frozen_solve=partial(
+            _romberg_levels,
+            divmax=divmax,
+            extrapolate=extrapolate,
+            batch_size=batch_size,
+        ),
     )
     y, state = adjoint.quadrature(ops, None, interval, args, consts, epsabs, epsrel, {})
     info = state["table"] if full_output else None
@@ -209,8 +236,50 @@ def _build_tanhsinh(interval, args, consts, *, f_conv):
     return wrap_func(fun_m, (), interval_m.dtype), interval_m
 
 
+def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype):
+    """Sum the integrand over the new nodes of one refinement level.
+
+    Level ``k`` adds the ``npts = 2**(k - 1)`` points sitting at odd multiples of ``h``
+    above ``a``, interleaving the nodes the previous levels already placed. ``npts`` is
+    only known at run time, so the points are evaluated in fixed size batches and the
+    last batch is padded up to a full one. Padding rather than shaping each level to its
+    own point count is what keeps one batch traced for all of them; the cost is that a
+    level with fewer points than a batch still pays for a whole one.
+
+    The padded lanes repeat the first point of their batch, which is always one this
+    level genuinely evaluates, not an arbitrary placeholder. An integrand that is
+    singular somewhere in the domain would return a non-finite value at a made up point,
+    and masking that out of the sum afterwards still leaves a NaN in its derivative.
+
+    ``vfunc`` takes a whole batch of abscissae; the callers wrap it to guarantee that.
+    """
+    nbatch = (npts + batch_size - 1) // batch_size
+    offs = jnp.arange(1, batch_size + 1)
+
+    def bodyfun(j, s):
+        i = j * batch_size + offs
+        used = i <= npts
+        x = a + h * (2 * i - 1)
+        x = jnp.where(used, x, x[0])
+        f: jax.Array = vfunc(x)
+        mask = used.reshape((-1,) + (1,) * (f.ndim - 1))
+        return s + jnp.sum(jnp.where(mask, f, 0), axis=0)
+
+    return jax.lax.fori_loop(0, nbatch, bodyfun, jnp.zeros(shape, dtype)), nbatch
+
+
 def _romberg_solve(
-    rule, vfunc, interval, epsabs, epsrel, kwargs, *, divmax, _norm, extrapolate=True
+    rule,
+    vfunc,
+    interval,
+    epsabs,
+    epsrel,
+    kwargs,
+    *,
+    divmax,
+    _norm,
+    extrapolate=True,
+    batch_size=1,
 ):
     """Run the refinement loop, with Richardson extrapolation if it is switched on.
 
@@ -220,6 +289,12 @@ def _romberg_solve(
     """
     del rule, kwargs
     a, b = interval
+    # Vectorize whatever we were handed The primal integrand arrives vectorized already,
+    # but the adjoints solve against one they build per point (the tangent or the
+    # cotangent of the mapped integrand) which takes a scalar only. Wrapping here rather
+    # than mapping at each use keeps one contract for the loop below: ``vfunc`` accepts
+    # a batch of abscissae.
+    vfunc = wrap_func(vfunc, (), interval.dtype)
     f = jax.eval_shape(vfunc, (a + b) / 2)
 
     # Which entry of row `k` is the estimate. Richardson's is the diagonal, having
@@ -247,18 +322,11 @@ def _romberg_solve(
         # loop over outer number of subdivisions
         result, n, neval, err = state
         h = (b - a) / 2**n
-        s = jnp.zeros(f.shape, f.dtype)
-
-        def sloop(i, s):
-            # loop to evaluate fun. Can't be vectorized due to different number
-            # of evals per nloop step
-            s += vfunc(a + h * (2 * i - 1))
-            return s
-
-        result = result.at[n, 0].set(
-            0.5 * result[n - 1, 0] + h * jax.lax.fori_loop(1, (2**n) // 2 + 1, sloop, s)
-        )
-        neval += (2**n) // 2
+        s, nbatch = _level_sum(vfunc, a, h, (2**n) // 2, batch_size, f.shape, f.dtype)
+        result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
+        # The padded lanes of the last batch are evaluations of the integrand like any
+        # other, so they are counted here even though they do not reach the sum.
+        neval += nbatch * batch_size
 
         def mloop(m, result):
             # richardson extrapolation
@@ -285,7 +353,9 @@ def _romberg_solve(
     return y, state
 
 
-def _romberg_levels(rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=True):
+def _romberg_levels(
+    rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=True, batch_size=1
+):
     """Evaluate the table at a fixed number of levels.
 
     With ``n`` fixed this is a fixed linear combination of the integrand at fixed nodes,
@@ -295,6 +365,7 @@ def _romberg_levels(rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=Tru
     """
     del rule, kwargs
     a, b = interval[0], interval[-1]
+    vfunc = wrap_func(vfunc, (), interval.dtype)  # see ``_romberg_solve``
     f = jax.eval_shape(vfunc, (a + b) / 2)
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
     # The trapezoid rule at one interval.
@@ -302,11 +373,7 @@ def _romberg_levels(rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=Tru
 
     def nloop(k, result):
         h = (b - a) / 2**k
-
-        def sloop(i, s):
-            return s + vfunc(a + h * (2 * i - 1))
-
-        s = jax.lax.fori_loop(1, (2**k) // 2 + 1, sloop, jnp.zeros(f.shape, f.dtype))
+        s, _ = _level_sum(vfunc, a, h, (2**k) // 2, batch_size, f.shape, f.dtype)
         result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
 
         def mloop(m, result):
@@ -333,6 +400,7 @@ def rombergts(
     norm: float | int | Callable[[jax.Array], jax.Array] = jnp.inf,
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
+    batch_size: int | None = None,
 ):
     """Romberg integration with tanh-sinh (aka double exponential) transformation.
 
@@ -387,6 +455,15 @@ def rombergts(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    batch_size : int, optional
+        Maximum number of points at which to evaluate the integrand in parallel. Default
+        is one at a time. Each refinement level doubles the number of new points, so
+        raising this is usually worth a lot on GPU/TPU, at the cost of peak memory
+        scaling with it. Levels with fewer new points than one batch are padded up to a
+        full batch, so the early levels of a run cost ``batch_size`` evaluations each
+        however few points they place; that padding is what keeps a single batch shape
+        traced for every level rather than one per level. Clipped to the largest level
+        ``divmax`` allows.
 
 
     Returns
@@ -410,9 +487,10 @@ def rombergts(
 
     Notes
     -----
-    Due to limitations on dynamically sized arrays in JAX, this algorithm is fully
-    sequential and does not vectorize integrand evaluations, so may not be the most
-    efficient on GPU/TPU.
+    The number of new points a refinement level places is only known at run time, so
+    there is no single shape to vectorize over. Integrand evaluations are made in
+    fixed size batches of ``batch_size``, defaulting to one at a time; raise it to get
+    parallelism on GPU/TPU.
 
     """
     interval = jnp.atleast_1d(jnp.asarray(interval))
@@ -432,6 +510,10 @@ def rombergts(
         epsrel = jnp.sqrt(jnp.finfo(dtypes.toltype).eps)
     epsabs = jnp.asarray(epsabs, dtypes.etype)
     epsrel = jnp.asarray(epsrel, dtypes.etype)
+    check_size(batch_size)
+    # No level ever places more than `2**(divmax - 1)` new points, so a larger batch
+    # would only ever be padding.
+    batch_size = min(batch_size or 1, 2 ** max(divmax - 1, 0))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -450,4 +532,5 @@ def rombergts(
         _build_tanhsinh,
         dtypes.xtype,
         extrapolate,
+        batch_size,
     )

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -453,34 +453,82 @@ def _decode_status(status):
 STATUS = {i: _decode_status(i) for i in range(int(2**6))}
 
 
-def wrap_func(fun: Callable[..., jax.Array], args: tuple[Any, ...], xtype):
+def wrap_func(
+    fun: Callable[..., jax.Array],
+    args: tuple[Any, ...],
+    xtype,
+    batch_size: int | None = None,
+):
     """Vectorize, jit, and mask out inf/nan.
 
     ``xtype`` is the dtype the integrand will be called at, and the integrand is probed
     at that dtype rather than at a weakly typed default. See the note on ``MAPFUNS``.
+
+    ``batch_size`` bounds how many points the returned function evaluates at once. The
+    default evaluates however many it is given.
     """
     f = jax.eval_shape(fun, jnp.zeros((), xtype), *args)
     # need to make sure we get the correct shape for array valued integrands
     outsig = "(" + ",".join("n" + str(i) for i in range(len(f.shape))) + ")"
 
-    return _WrappedFunction(fun, args, outsig)
+    return _WrappedFunction(fun, args, outsig, batch_size)
 
 
 class _WrappedFunction(eqx.Module):
-    """Wraps a function in jit/vectorize and masks out inf/nans."""
+    """Wraps a function in jit/vectorize and masks out inf/nans.
+
+    Evaluates at most ``batch_size`` points at once, scanning over the batches. The
+    number of points is fixed at trace time here, so the batches are cut to fit rather
+    than the points being padded up to a whole number of batches: the leftovers are
+    evaluated together in one smaller batch. That costs one extra tracing of the
+    integrand and never an extra evaluation of it, which is the right way round when an
+    evaluation is the expensive part, which is the case ``batch_size`` exists for.
+
+    Callers whose point count is only known at run time cannot do this, and pad instead;
+    see ``_level_sum`` in the Romberg solver.
+    """
 
     fun: Callable[..., jax.Array]
     args: tuple[Any, ...]
     outsig: str
+    batch_size: int | None = None
 
-    @eqx.filter_jit
-    def __call__(self, x: jax.Array) -> jax.Array:
-        f: jax.Array = jnp.vectorize(
+    def _vectorize(self, x: jax.Array) -> jax.Array:
+        return jnp.vectorize(
             self.fun,
             excluded=tuple(range(1, len(self.args) + 1)),
             signature="()->" + self.outsig,
         )(x, *self.args)
+
+    @eqx.filter_jit
+    def __call__(self, x: jax.Array) -> jax.Array:
+        b = self.batch_size
+        # A scalar abscissa has nothing to batch: Romberg calls the integrand one point
+        # at a time, and every caller probes it with a scalar under eval_shape.
+        if b is None or x.ndim == 0 or x.shape[0] <= b:
+            f: jax.Array = self._vectorize(x)
+        else:
+            n = x.shape[0]
+            nfull = n // b
+            full = jax.lax.map(self._vectorize, x[: nfull * b].reshape(nfull, b))
+            parts = [full.reshape(-1, *full.shape[2:])]
+            if n % b:
+                parts.append(self._vectorize(x[nfull * b :]))
+            f = jnp.concatenate(parts)
         return jnp.where(jnp.isfinite(f), f, 0.0)
+
+
+def check_size(size: int | None, name: str = "batch_size") -> None:
+    """Raise if ``size`` is neither ``None`` nor a positive integer.
+
+    Shared by the options that set how many evaluations are grouped together:
+    ``batch_size`` on the quadrature routines and ``chunk_size`` on the adjoints.
+    """
+    errorif(
+        size is not None and (not isinstance(size, (int, np.integer)) or size < 1),
+        ValueError,
+        f"{name} must be None or a positive integer, got {size}",
+    )
 
 
 class QuadratureInfo(NamedTuple):

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -828,3 +828,99 @@ print("ok")
     )
     assert out.returncode == 0, out.stderr
     assert "ok" in out.stdout
+
+
+# Straddling the node count of the default rule for each routine: one point at a time, a
+# size that leaves a partial last batch, and one above the node count so the clip fires.
+BATCH_SIZES = [1, 4, 7, 10**4]
+
+
+@pytest.mark.parametrize("method", [quadgk, quadcc, quadts], ids=["gk", "cc", "ts"])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+class TestBatchSize:
+    """Splitting the local rule's node evaluation into batches.
+
+    The rule's node count is fixed when it is built, so the batches are cut to fit and
+    the subdivision loop sees the same values it would have seen unbatched, in the same
+    order, with no term reordered. That is a stronger claim than Romberg's, where the
+    level sizes are dynamic and batching does reassociate a sum, and it is checked as
+    such: the tolerance below is ULP-scale rather than the one the quadrature was asked
+    for.
+
+    It is deliberately not asserted bitwise. Evaluating the integrand under a different
+    batch shape lets XLA fuse the arithmetic differently, which can move a result by
+    around eps with no reordering involved, so a bitwise assertion would be testing the
+    compiler rather than this option. ``batch_size`` is a statement about memory and
+    scheduling, and the tests below are what pins it to that.
+    """
+
+    TOL = 1e-10
+
+    @pytest.mark.parametrize("i", [0, 17])
+    @pytest.mark.parametrize("extrapolate", [False, True], ids=["plain", "extrap"])
+    def test_run_is_unchanged(self, method, batch_size, i, extrapolate):
+        """Value, error estimate, status and subdivision all come out identical."""
+        prob = PROBLEMS[i]
+        run = lambda bs: method(  # noqa: E731
+            prob["fun"],
+            prob["interval"],
+            epsabs=self.TOL,
+            epsrel=self.TOL,
+            full_output=True,
+            extrapolate=extrapolate,
+            batch_size=bs,
+        )
+        y, info = run(None)
+        y_b, info_b = run(batch_size)
+        np.testing.assert_allclose(
+            np.asarray(y_b), np.asarray(y), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+        np.testing.assert_allclose(
+            np.asarray(info_b.err), np.asarray(info.err), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+        assert int(info_b.status) == int(info.status)
+        assert int(info_b.info["ninter"]) == int(info.info["ninter"])
+
+    @pytest.mark.usefixtures("quiet_tanhsinh")
+    @pytest.mark.parametrize("dtype", real_dtypes)
+    def test_dtypes(self, method, batch_size, dtype):
+        """Padding must not disturb the working precision.
+
+        The fill is taken from the abscissae themselves, so it carries their dtype and
+        cannot promote the batch; a literal would.
+        """
+        y, info = method(
+            exp_neg,
+            jnp.array([0.0, 1.0], dtype),
+            epsabs=jnp.array(1e-3, dtype),
+            epsrel=jnp.array(1e-3, dtype),
+            batch_size=batch_size,
+        )
+        assert y.dtype == dtype
+        tol = SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
+        np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=tol)
+
+    def test_neval_does_not_move(self, method, batch_size):
+        """Batching costs no extra evaluations, so the reported count is unchanged.
+
+        The node count is fixed when the rule is built, so a batch size that does not
+        divide it leaves a smaller final batch rather than a padded one. This is the
+        test that would fail if the remainder were ever padded instead.
+        """
+        prob = PROBLEMS[0]
+        run = lambda bs: method(  # noqa: E731
+            prob["fun"],
+            prob["interval"],
+            epsabs=self.TOL,
+            epsrel=self.TOL,
+            batch_size=bs,
+        )[1]
+        assert int(run(batch_size).neval) == int(run(None).neval)
+
+
+@pytest.mark.parametrize("method", [quadgk, quadcc, quadts], ids=["gk", "cc", "ts"])
+@pytest.mark.parametrize("batch_size", [0, -1, 2.5], ids=["zero", "negative", "float"])
+def test_bad_batch_size_rejected(method, batch_size):
+    """A batch size that is not a positive integer is a mistake, not a default."""
+    with pytest.raises(ValueError, match="batch_size"):
+        method(exp_neg, jnp.array([0.0, 1.0]), batch_size=batch_size)

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -835,8 +835,39 @@ print("ok")
 BATCH_SIZES = [1, 4, 7, 10**4]
 
 
-@pytest.mark.parametrize("method", [quadgk, quadcc, quadts], ids=["gk", "cc", "ts"])
-@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+# A size that leaves a partial last batch, so the two-trace path is the one taken
+# wherever a single size has to stand for the list above.
+PARTIAL_BATCH = 7
+BATCH_TOL = 1e-10
+
+
+def _run_batched(method, batch_size, i=0, extrapolate=True):
+    prob = PROBLEMS[i]
+    return method(
+        prob["fun"],
+        prob["interval"],
+        epsabs=BATCH_TOL,
+        epsrel=BATCH_TOL,
+        full_output=True,
+        extrapolate=extrapolate,
+        batch_size=batch_size,
+    )
+
+
+def _assert_same_run(got, want):
+    """Value, error estimate, status and subdivision all agree to roundoff."""
+    (y_b, info_b), (y, info) = got, want
+    np.testing.assert_allclose(
+        np.asarray(y_b), np.asarray(y), rtol=ULP_RTOL, atol=ULP_ATOL
+    )
+    np.testing.assert_allclose(
+        np.asarray(info_b.err), np.asarray(info.err), rtol=ULP_RTOL, atol=ULP_ATOL
+    )
+    assert int(info_b.status) == int(info.status)
+    assert int(info_b.info["ninter"]) == int(info.info["ninter"])
+
+
+@pytest.mark.parametrize("method", [quadgk], ids=["gk"])
 class TestBatchSize:
     """Splitting the local rule's node evaluation into batches.
 
@@ -854,68 +885,57 @@ class TestBatchSize:
     scheduling, and the tests below are what pins it to that.
     """
 
-    TOL = 1e-10
-
-    @pytest.mark.parametrize("i", [0, 17])
-    @pytest.mark.parametrize("extrapolate", [False, True], ids=["plain", "extrap"])
-    def test_run_is_unchanged(self, method, batch_size, i, extrapolate):
+    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+    def test_run_is_unchanged(self, method, batch_size):
         """Value, error estimate, status and subdivision all come out identical."""
-        prob = PROBLEMS[i]
-        run = lambda bs: method(  # noqa: E731
-            prob["fun"],
-            prob["interval"],
-            epsabs=self.TOL,
-            epsrel=self.TOL,
-            full_output=True,
-            extrapolate=extrapolate,
-            batch_size=bs,
-        )
-        y, info = run(None)
-        y_b, info_b = run(batch_size)
-        np.testing.assert_allclose(
-            np.asarray(y_b), np.asarray(y), rtol=ULP_RTOL, atol=ULP_ATOL
-        )
-        np.testing.assert_allclose(
-            np.asarray(info_b.err), np.asarray(info.err), rtol=ULP_RTOL, atol=ULP_ATOL
-        )
-        assert int(info_b.status) == int(info.status)
-        assert int(info_b.info["ninter"]) == int(info.info["ninter"])
+        _assert_same_run(_run_batched(method, batch_size), _run_batched(method, None))
 
     @pytest.mark.usefixtures("quiet_tanhsinh")
     @pytest.mark.parametrize("dtype", real_dtypes)
-    def test_dtypes(self, method, batch_size, dtype):
-        """Padding must not disturb the working precision.
+    def test_dtypes(self, method, dtype):
+        """Batching must not disturb the working precision.
 
-        The fill is taken from the abscissae themselves, so it carries their dtype and
-        cannot promote the batch; a literal would.
+        Slicing and rejoining the abscissae carries their dtype through, so the batched
+        run is asked for its answer in the same precision the unbatched one is.
         """
         y, info = method(
             exp_neg,
             jnp.array([0.0, 1.0], dtype),
             epsabs=jnp.array(1e-3, dtype),
             epsrel=jnp.array(1e-3, dtype),
-            batch_size=batch_size,
+            batch_size=PARTIAL_BATCH,
         )
         assert y.dtype == dtype
         tol = SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
         np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=tol)
 
+    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
     def test_neval_does_not_move(self, method, batch_size):
         """Batching costs no extra evaluations, so the reported count is unchanged.
 
         The node count is fixed when the rule is built, so a batch size that does not
         divide it leaves a smaller final batch rather than a padded one. This is the
-        test that would fail if the remainder were ever padded instead.
+        test that would fail if the remainder were ever padded instead, and it is the
+        one that would catch ``neval`` being scaled by the order where the rule's node
+        count is something else.
         """
-        prob = PROBLEMS[0]
-        run = lambda bs: method(  # noqa: E731
-            prob["fun"],
-            prob["interval"],
-            epsabs=self.TOL,
-            epsrel=self.TOL,
-            batch_size=bs,
-        )[1]
+        run = lambda bs: _run_batched(method, bs)[1]  # noqa: E731
         assert int(run(batch_size).neval) == int(run(None).neval)
+
+
+@pytest.mark.parametrize("i", [0, 17], ids=str)
+@pytest.mark.parametrize("extrapolate", [False, True], ids=["plain", "extrap"])
+def test_batch_size_is_independent_of_extrapolation(i, extrapolate):
+    """The acceleration reads the sequence of results, not how each was evaluated.
+
+    So it has nothing to interact with, on an easy problem or on one whose tail the
+    extrapolation is what resolves. Run through one routine, since the subdivision loop
+    and the acceleration around it are shared by all three.
+    """
+    _assert_same_run(
+        _run_batched(quadgk, PARTIAL_BATCH, i, extrapolate),
+        _run_batched(quadgk, None, i, extrapolate),
+    )
 
 
 @pytest.mark.parametrize("method", [quadgk, quadcc, quadts], ids=["gk", "cc", "ts"])

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -47,6 +47,12 @@ all_methods = adaptive_methods + romberg_methods
 # accuracy is part of what is under test.
 machinery_methods = [quadgk]
 
+# One routine from each family that groups its integrand evaluations differently. The
+# adaptive routines share the wrapper that cuts the batches to fit a node count known
+# when the rule is built; the Romberg pair pads instead, because a level's size is only
+# known at run time, and rombergts pads a mapped integrand.
+batching_families = [quadgk, romberg, rombergts]
+
 # problems exercising the paths that differ: plain, interior breakpoints, an infinite
 # limit, and a vector valued integrand.
 example_problems = [
@@ -1018,12 +1024,29 @@ class TestBatchSize:
     the sum over each level.
     """
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize("adjoint", adjoints, ids=adjoint_ids)
     @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev], ids=["fwd", "rev"])
-    @pytest.mark.parametrize("i", range(len(example_problems)))
-    def test_adaptive_matches_unbatched(self, quad, adjoint, transform, i):
+    def test_adaptive_matches_unbatched(self, quad, adjoint, transform):
         """Same derivative, in either mode, under either adjoint."""
+        self._check_adaptive(quad, adjoint, transform, 0)
+
+    # The problems a batched rule application can tell apart from the plain finite one
+    # the tests above run on. An infinite limit, because the abscissae the batches slice
+    # are then the mapped ones rather than the interval's own; and a vector valued
+    # integrand, whose values carry trailing axes that slicing the leading one has to
+    # leave alone. Interior breakpoints are deliberately not among them: they change the
+    # subdivision, and batching happens strictly within a single application of the
+    # rule, so they would re-run the plain case under another name.
+    SHAPES = [3, 4]
+    SHAPE_IDS = ["infinite", "vector"]
+
+    @pytest.mark.parametrize("i", SHAPES, ids=SHAPE_IDS)
+    def test_adaptive_over_problem_shapes(self, i):
+        """And on the shapes of problem a batched rule application can tell apart."""
+        self._check_adaptive(quadgk, adjoints[0], jax.jacrev, i)
+
+    def _check_adaptive(self, quad, adjoint, transform, i):
         prob = example_problems[i]
         interval = jnp.asarray(prob["interval"])
         make = lambda bs: (
@@ -1060,7 +1083,7 @@ class TestBatchSize:
         got = float(transform(make(8))(args))
         np.testing.assert_allclose(got, want, rtol=1e-10, atol=1e-12)
 
-    @pytest.mark.parametrize("quad", all_methods)
+    @pytest.mark.parametrize("quad", batching_families)
     def test_wrt_interval(self, quad):
         """The limits are differentiated with respect to as well as the args."""
         fun = lambda t: jnp.exp(-(t**2))  # noqa: E731
@@ -1073,7 +1096,7 @@ class TestBatchSize:
             atol=1e-12,
         )
 
-    @pytest.mark.parametrize("quad", all_methods)
+    @pytest.mark.parametrize("quad", batching_families)
     def test_padding_introduces_no_new_nan(self, quad):
         """An integrand singular at a limit, where a careless fill would land.
 
@@ -1096,7 +1119,7 @@ class TestBatchSize:
         got = np.isfinite(np.asarray(f(3)))
         np.testing.assert_array_equal(got, want)
 
-    @pytest.mark.parametrize("quad", all_methods)
+    @pytest.mark.parametrize("quad", batching_families)
     def test_vmap(self, quad):
         """Batching sits inside the loops that ``vmap`` already has to survive."""
         fun = lambda t, c: jnp.exp(-c * t**2)  # noqa: E731
@@ -1127,17 +1150,48 @@ class TestChunkSize:
     it must not move the derivative - unused slots in a chunk are handed a real
     sub-interval and masked out, so the chunking changes only the order the same
     contributions are summed in.
+
+    The blocking is done on the subdivision alone and never looks at the local rule, so
+    these run through ``machinery_methods`` rather than all three adaptive routines.
     """
 
-    @pytest.mark.parametrize("quad", adaptive_methods)
+    # Straddling the number of slots in the subdivision: one sub-interval at a time, a
+    # size leaving a partial last chunk, the default, and one above the slot count so
+    # the clip fires.
+    CHUNK_SIZES = [1, 3, 8, 64]
+
+    @pytest.mark.parametrize("quad", machinery_methods)
     @pytest.mark.parametrize(
         "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
     )
     @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev], ids=["fwd", "rev"])
-    @pytest.mark.parametrize("chunk_size", [1, 3, 8, 64], ids=str)
-    @pytest.mark.parametrize("i", range(len(example_problems)))
-    def test_derivative_is_unchanged(self, quad, adjoint, transform, chunk_size, i):
+    @pytest.mark.parametrize("chunk_size", CHUNK_SIZES, ids=str)
+    def test_derivative_is_unchanged(self, quad, adjoint, transform, chunk_size):
         """Every chunk size gives the derivative the default one gives."""
+        self._check(quad, adjoint, transform, chunk_size, 0)
+
+    # The subdivisions that differ in what the chunking has to do with them, beyond the
+    # plain finite one the test above runs on. Interior breakpoints give the frozen mesh
+    # more than one owner, so rebuilding the endpoints a chunk covers is a different
+    # computation; an infinite limit puts that mesh in mapped coordinates; and a vector
+    # valued integrand is what forces the mask over a chunk's unused slots to broadcast
+    # against trailing axes rather than matching the contributions elementwise.
+    SHAPES = [1, 3, 4]
+    SHAPE_IDS = ["breakpoints", "infinite", "vector"]
+
+    @pytest.mark.parametrize(
+        "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
+    )
+    @pytest.mark.parametrize("i", SHAPES, ids=SHAPE_IDS)
+    def test_over_problem_shapes(self, adjoint, i):
+        """And does so on each shape of subdivision there is to chunk.
+
+        A chunk size that does not divide the slot count is the one that pads, so that
+        is the size these run at.
+        """
+        self._check(quadgk, adjoint, jax.jacrev, 3, i)
+
+    def _check(self, quad, adjoint, transform, chunk_size, i):
         prob = example_problems[i]
         interval = jnp.asarray(prob["interval"])
         make = lambda adj: (

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -1001,3 +1001,204 @@ class TestExtrapolatedAdjoints:
         second = np.asarray(d1(d2(f))(x))
         assert np.all(np.isfinite(second))
         np.testing.assert_allclose(second, 0.0, atol=1e-9)
+
+
+class TestBatchSize:
+    """Batching integrand evaluations must not disturb the derivatives.
+
+    It puts new control flow in the differentiated path of both families: a ``scan``
+    node batches inside the adaptive rules, and a dynamically bounded loop over point
+    batches inside the Romberg levels. Romberg also introduces padded lanes, since its
+    level sizes are only known at run time; those are substituted rather than masked
+    precisely so they cannot poison a gradient, which is what the NaN check below is
+    for.
+
+    The adaptive comparison is at ULP scale, since cutting the batches to fit leaves the
+    arithmetic the same. Romberg's is looser, because batching does reassociate
+    the sum over each level.
+    """
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize("adjoint", adjoints, ids=adjoint_ids)
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev], ids=["fwd", "rev"])
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_adaptive_matches_unbatched(self, quad, adjoint, transform, i):
+        """Same derivative, in either mode, under either adjoint."""
+        prob = example_problems[i]
+        interval = jnp.asarray(prob["interval"])
+        make = lambda bs: (
+            lambda a: quad(  # noqa: E731
+                prob["fun"], interval, a, adjoint=adjoint, batch_size=bs
+            )[0]
+        )
+        want = transform(make(None))(prob["args"])
+        got = transform(make(4))(prob["args"])
+        want, got = jax.tree.leaves(want)[0], jax.tree.leaves(got)[0]
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods, ids=["romberg", "ts"])
+    @pytest.mark.parametrize("adjoint", adjoints, ids=adjoint_ids)
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev], ids=["fwd", "rev"])
+    def test_romberg_matches_unbatched(self, quad, adjoint, transform):
+        """Reverse mode included, which for Romberg goes through the custom primitive.
+
+        ``DirectAdjoint`` freezes the number of levels and replays them, and that replay
+        has to batch its points exactly as the solve did. Batching one and not the other
+        would differentiate a discretization that was never evaluated.
+        """
+        fun = lambda t, c: jnp.exp(-c * t**2)  # noqa: E731
+        interval = jnp.array([0.0, 2.0])
+        args = jnp.asarray(0.7)
+        make = lambda bs: (
+            lambda c: quad(  # noqa: E731
+                fun, interval, (c,), divmax=10, adjoint=adjoint, batch_size=bs
+            )[0]
+        )
+        want = float(transform(make(None))(args))
+        got = float(transform(make(8))(args))
+        np.testing.assert_allclose(got, want, rtol=1e-10, atol=1e-12)
+
+    @pytest.mark.parametrize("quad", all_methods)
+    def test_wrt_interval(self, quad):
+        """The limits are differentiated with respect to as well as the args."""
+        fun = lambda t: jnp.exp(-(t**2))  # noqa: E731
+        make = lambda bs: lambda iv: quad(fun, iv, batch_size=bs)[0]  # noqa: E731
+        iv = jnp.array([0.0, 2.0])
+        np.testing.assert_allclose(
+            np.asarray(jax.jacfwd(make(4))(iv)),
+            np.asarray(jax.jacfwd(make(None))(iv)),
+            rtol=1e-10,
+            atol=1e-12,
+        )
+
+    @pytest.mark.parametrize("quad", all_methods)
+    def test_padding_introduces_no_new_nan(self, quad):
+        """An integrand singular at a limit, where a careless fill would land.
+
+        Romberg's padded lanes repeat a point their batch genuinely evaluates, not a
+        made up one, so they can only ever ask the integrand for a value it is already
+        being asked for. Filling them with a placeholder would mask the value but leave
+        a NaN in its derivative, which masking afterwards does not remove. The adaptive
+        routines pad nothing and are here to show the claim holds trivially for them.
+
+        The claim is that batching adds no NaN, not that there is none: a closed rule
+        (and Romberg's trapezoidal level zero) places a node on the singularity itself
+        and has an unusable derivative there whatever the batch size. So the batched run
+        is held to what the unbatched one already manages, component by component.
+        """
+        fun = lambda t, c: jnp.log(c * t)  # noqa: E731
+        f = lambda bs: jax.grad(  # noqa: E731
+            lambda c: quad(fun, jnp.array([0.0, 1.0]), (c,), batch_size=bs)[0]
+        )(jnp.asarray(2.0))
+        want = np.isfinite(np.asarray(f(None)))
+        got = np.isfinite(np.asarray(f(3)))
+        np.testing.assert_array_equal(got, want)
+
+    @pytest.mark.parametrize("quad", all_methods)
+    def test_vmap(self, quad):
+        """Batching sits inside the loops that ``vmap`` already has to survive."""
+        fun = lambda t, c: jnp.exp(-c * t**2)  # noqa: E731
+        f = lambda c: quad(  # noqa: E731
+            fun, jnp.array([0.0, 2.0]), (c,), batch_size=4
+        )[0]
+        cs = jnp.array([0.5, 0.7, 1.1])
+        np.testing.assert_allclose(
+            np.asarray(jax.vmap(f)(cs)),
+            np.asarray(jnp.array([f(c) for c in cs])),
+            rtol=1e-10,
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            np.asarray(jax.vmap(jax.grad(f))(cs)),
+            np.asarray(jnp.array([jax.grad(f)(c) for c in cs])),
+            rtol=1e-10,
+            atol=1e-12,
+        )
+
+
+class TestChunkSize:
+    """How many sub-intervals of the frozen subdivision an adjoint evaluates at once.
+
+    The reverse-mode counterpart of ``batch_size``: that one bounds the work within a
+    sub-interval, this one bounds how many sub-intervals are in flight together. It is
+    purely a memory-against-speed choice, so like ``batch_size`` on the adaptive rules
+    it must not move the derivative - unused slots in a chunk are handed a real
+    sub-interval and masked out, so the chunking changes only the order the same
+    contributions are summed in.
+    """
+
+    @pytest.mark.parametrize("quad", adaptive_methods)
+    @pytest.mark.parametrize(
+        "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
+    )
+    @pytest.mark.parametrize("transform", [jax.jacfwd, jax.jacrev], ids=["fwd", "rev"])
+    @pytest.mark.parametrize("chunk_size", [1, 3, 8, 64], ids=str)
+    @pytest.mark.parametrize("i", range(len(example_problems)))
+    def test_derivative_is_unchanged(self, quad, adjoint, transform, chunk_size, i):
+        """Every chunk size gives the derivative the default one gives."""
+        prob = example_problems[i]
+        interval = jnp.asarray(prob["interval"])
+        make = lambda adj: (
+            lambda a: quad(  # noqa: E731
+                prob["fun"], interval, a, adjoint=adj
+            )[0]
+        )
+        want = transform(make(adjoint()))(prob["args"])
+        got = transform(make(adjoint(chunk_size=chunk_size)))(prob["args"])
+        np.testing.assert_allclose(
+            np.asarray(jax.tree.leaves(got)[0]),
+            np.asarray(jax.tree.leaves(want)[0]),
+            rtol=ULP_RTOL,
+            atol=ULP_ATOL,
+        )
+
+    @pytest.mark.parametrize(
+        "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
+    )
+    def test_composes_with_batch_size(self, adjoint):
+        """The two knobs are independent, and multiply to the real parallel width."""
+        prob = example_problems[0]
+        interval = jnp.asarray(prob["interval"])
+        f = lambda adj, bs: jax.jacrev(  # noqa: E731
+            lambda a: quadgk(prob["fun"], interval, a, adjoint=adj, batch_size=bs)[0]
+        )(prob["args"])
+        want = f(adjoint(), None)
+        got = f(adjoint(chunk_size=3), 4)
+        np.testing.assert_allclose(
+            np.asarray(jax.tree.leaves(got)[0]),
+            np.asarray(jax.tree.leaves(want)[0]),
+            rtol=ULP_RTOL,
+            atol=ULP_ATOL,
+        )
+
+    @pytest.mark.parametrize(
+        "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
+    )
+    def test_romberg_is_unaffected(self, adjoint):
+        """Romberg has no subdivision to chunk, so the option is simply inert there."""
+        f = lambda adj: float(  # noqa: E731
+            jax.grad(
+                lambda c: romberg(
+                    lambda t, c_: jnp.exp(-c_ * t**2),
+                    jnp.array([0.0, 2.0]),
+                    (c,),
+                    adjoint=adj,
+                )[0]
+            )(jnp.asarray(0.7))
+        )
+        np.testing.assert_allclose(
+            f(adjoint(chunk_size=2)), f(adjoint()), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+
+    @pytest.mark.parametrize(
+        "adjoint", [DirectAdjoint, LeibnizAdjoint], ids=adjoint_ids
+    )
+    @pytest.mark.parametrize(
+        "chunk_size", [0, -1, 2.5], ids=["zero", "negative", "float"]
+    )
+    def test_bad_chunk_size_rejected(self, adjoint, chunk_size):
+        """Rejected when the adjoint is built, not on first use."""
+        with pytest.raises(ValueError, match="chunk_size"):
+            adjoint(chunk_size=chunk_size)

--- a/tests/test_fixed_order.py
+++ b/tests/test_fixed_order.py
@@ -35,7 +35,7 @@ from jax import config
 
 from quadax import ClenshawCurtisRule, GaussKronrodRule, TanhSinhRule
 
-from .problems import SLOP, exp_neg, real_dtypes
+from .problems import SLOP, ULP_ATOL, ULP_RTOL, exp_neg, real_dtypes
 
 config.update("jax_enable_x64", True)
 
@@ -300,3 +300,83 @@ def test_tanhsinh_nodes_stay_inside_the_interval(dtype):
     assert xh.dtype == dtype
     assert len(np.unique(np.asarray(xh, dtype=np.float64))) == len(xh)
     assert np.all(np.abs(np.asarray(xh, dtype=np.float64)) < 1.0)
+
+
+# The batch sizes worth covering, relative to a rule's node count ``n``: one point at a
+# time, a divisor of nothing in particular so the last batch is partial, an exact
+# divisor of nothing again but larger, and a value above ``n`` so the clip fires. Given
+# as a callable of ``n`` because the three rules have different node counts, and the
+# interesting values are the ones that straddle it.
+BATCH_SIZES = [
+    lambda n: 1,
+    lambda n: 4,
+    lambda n: 5,
+    lambda n: n - 1,
+    lambda n: n,
+    lambda n: n + 7,
+]
+BATCH_IDS = ["1", "4", "5", "n-1", "n", "n+7"]
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+@pytest.mark.parametrize("rule", RULES)
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=BATCH_IDS)
+class TestBatchSize:
+    """Splitting the node evaluation into batches must not change the answer.
+
+    The node count is fixed when the rule is built, so the batches are cut to fit: the
+    weighted sums see the same values an unbatched rule computes, in the same order,
+    with no term reassociated, and the agreement is to the last few ulp rather than to
+    the tolerance the quadrature was asked for. It is not bitwise, and
+    must not be asserted as such, evaluating the integrand under a different batch
+    shape lets XLA fuse the arithmetic differently, which moves results by around eps
+    without any reordering having happened.
+    """
+
+    def test_integrate_is_unchanged(self, rule, batch_size):
+        """All four outputs match the unbatched rule to within roundoff."""
+        n = len(rule()._xh)
+        want = rule().integrate(exp_neg, 0.0, 1.0, ())
+        got = rule(batch_size=batch_size(n)).integrate(exp_neg, 0.0, 1.0, ())
+        for w, g in zip(want, got):
+            np.testing.assert_allclose(
+                np.asarray(g), np.asarray(w), rtol=ULP_RTOL, atol=ULP_ATOL
+            )
+
+    def test_apply_is_unchanged(self, rule, batch_size):
+        """And so does the value-only path the adjoints use."""
+        n = len(rule()._xh)
+        want = rule()._apply(exp_neg, 0.0, 1.0, ())
+        got = rule(batch_size=batch_size(n))._apply(exp_neg, 0.0, 1.0, ())
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+
+    def test_vector_valued(self, rule, batch_size):
+        """Batching slices the leading axis, so it must survive extra trailing ones."""
+        fun = lambda x: jnp.array([jnp.sin(x), jnp.cos(x), x**2])  # noqa: E731
+        n = len(rule()._xh)
+        want = rule().integrate(fun, 0.0, 1.0, ())
+        got = rule(batch_size=batch_size(n)).integrate(fun, 0.0, 1.0, ())
+        for w, g in zip(want, got):
+            np.testing.assert_allclose(
+                np.asarray(g), np.asarray(w), rtol=ULP_RTOL, atol=ULP_ATOL
+            )
+
+    def test_nodes_per_call(self, rule, batch_size):
+        """Batching regroups the nodes, it does not add any.
+
+        The remainder is evaluated in one smaller batch rather than padded up, so no
+        batch size costs an evaluation the unbatched rule would not have made.
+        """
+        n = len(rule()._xh)
+        assert rule(batch_size=batch_size(n)).nodes_per_call == n
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+@pytest.mark.parametrize("rule", RULES)
+@pytest.mark.parametrize("batch_size", [0, -1, 2.5], ids=["zero", "negative", "float"])
+def test_bad_batch_size_rejected(rule, batch_size):
+    """A batch size that is not a positive integer is a mistake, not a default."""
+    with pytest.raises(ValueError, match="batch_size"):
+        rule(batch_size=batch_size)

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -195,6 +195,9 @@ class TestBatchSize:
 
     DIVMAX = 8
     BATCH_SIZES = [1, 3, 8, 16, 64]
+    # A size that pads every level below the deepest, so the padded path is the one
+    # taken wherever a single size has to stand for the list.
+    PADS = 3
 
     def _run(self, method, i, batch_size, divmax=None):
         """Run to a fixed depth, so every batch size does the same amount of work.
@@ -231,9 +234,7 @@ class TestBatchSize:
             total += -(-(2**level) // b) * b
         raise AssertionError(f"neval={int(info.neval)} matches no depth at b={b}")
 
-    @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
-    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
-    def test_matches_the_serial_run(self, method, i, batch_size):
+    def _assert_matches_serial(self, method, i, batch_size):
         """At the same depth, batching changes only the rounding of the sums.
 
         The trapezoidal column is compared as well as the value, since it is what the
@@ -259,8 +260,25 @@ class TestBatchSize:
             columns[0][:depth], columns[1][:depth], rtol=1e-11, atol=1e-13
         )
 
+    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+    def test_matches_the_serial_run(self, method, batch_size):
+        """Across the batch sizes, from one point at a time to more than a level.
+
+        The largest is above the deepest level's point count, so the clip fires.
+        """
+        self._assert_matches_serial(method, SMOOTH_FINITE[0], batch_size)
+
     @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
-    def test_serial_is_the_default(self, method, i):
+    def test_matches_the_serial_run_over_integrands(self, method, i):
+        """And across integrands, since what batching reassociates is their sum.
+
+        One batch size stands for the list here: which points land in which batch is a
+        property of the level sizes, which the integrand has no say in, so the integrand
+        varies against the size that pads rather than against all of them.
+        """
+        self._assert_matches_serial(method, i, self.PADS)
+
+    def test_serial_is_the_default(self, method):
         """``batch_size=None`` and ``batch_size=1`` are the same computation.
 
         One point per batch leaves the mask always true and the sum over a single row,
@@ -268,8 +286,8 @@ class TestBatchSize:
         quadrature accuracy. Not bitwise: the batched form still evaluates the integrand
         under a ``vmap`` of width one, and XLA is free to fuse that differently.
         """
-        want, _ = self._run(method, i, None)
-        got, _ = self._run(method, i, 1)
+        want, _ = self._run(method, SMOOTH_FINITE[0], None)
+        got, _ = self._run(method, SMOOTH_FINITE[0], 1)
         np.testing.assert_allclose(
             np.asarray(got), np.asarray(want), rtol=ULP_RTOL, atol=ULP_ATOL
         )

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -177,3 +177,141 @@ class TestRichardsonFlag:
         np.testing.assert_allclose(
             columns[0][:depth], columns[1][:depth], rtol=ULP_RTOL, atol=ULP_ATOL
         )
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+class TestBatchSize:
+    """Evaluating a level's new points in parallel rather than one at a time.
+
+    A level places ``2**(k-1)`` new points, a count only known at run time, so they are
+    evaluated in fixed size batches with the last one padded. The padding is what lets a
+    single batch shape serve every level; the price is that early levels, which place
+    fewer points than a batch holds, still pay for a whole one.
+
+    Batching reorders the sum over a level, from strictly sequential to pairwise
+    within each batch, so the answers move in the last bits. That is why the comparisons
+    here are to a tolerance rather than exact.
+    """
+
+    DIVMAX = 8
+    BATCH_SIZES = [1, 3, 8, 16, 64]
+
+    def _run(self, method, i, batch_size, divmax=None):
+        """Run to a fixed depth, so every batch size does the same amount of work.
+
+        ``epsabs=epsrel=0`` stops the tolerance from being met, so the loop always
+        exhausts ``divmax``. Without that a batch size could stop a level earlier or
+        later than the serial run purely on the last-bit differences above, and the
+        comparison would be between two different discretizations.
+        """
+        prob = PROBLEMS[i]
+        return method(
+            prob["fun"],
+            jnp.asarray(prob["interval"], float),
+            epsabs=0.0,
+            epsrel=0.0,
+            divmax=divmax or self.DIVMAX,
+            full_output=True,
+            batch_size=batch_size,
+        )
+
+    def _depth(self, info, batch_size):
+        """How many refinement levels a run performed, read off its evaluation count.
+
+        For a fixed batch size ``neval`` is strictly increasing in the depth, so it
+        identifies it. Taken from the count rather than from where the table stops being
+        filled, because a problem whose integral is zero fills it with zeros and there
+        nothing to find.
+        """
+        b = batch_size or 1
+        total = 2
+        for level in range(self.DIVMAX + 1):
+            if total == int(info.neval):
+                return level
+            total += -(-(2**level) // b) * b
+        raise AssertionError(f"neval={int(info.neval)} matches no depth at b={b}")
+
+    @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
+    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+    def test_matches_the_serial_run(self, method, i, batch_size):
+        """At the same depth, batching changes only the rounding of the sums.
+
+        The trapezoidal column is compared as well as the value, since it is what the
+        batched sum feeds directly and the rest of the table is built from it by a
+        deterministic recurrence.
+
+        Only as far as both runs got. Zeroing the tolerance does not quite pin depth:
+        the loop also stops when two successive estimates agree to the last bit, on a
+        problem this converges on, whether that happens at the second to last level is
+        decided by a difference of a few ulp that batching is entitled to move. So the
+        depths can differ by one, and ``status`` (which under a zero tolerance reports
+        only whether that difference was nonzero) is not compared at all.
+        """
+        want, want_info = self._run(method, i, None)
+        got, got_info = self._run(method, i, batch_size)
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=1e-11, atol=1e-13
+        )
+        columns = [np.asarray(o.info)[:, 0] for o in (got_info, want_info)]
+        depth = min(self._depth(got_info, batch_size), self._depth(want_info, None))
+        assert depth > 1, "neither run filled the trapezoidal column"
+        np.testing.assert_allclose(
+            columns[0][:depth], columns[1][:depth], rtol=1e-11, atol=1e-13
+        )
+
+    @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
+    def test_serial_is_the_default(self, method, i):
+        """``batch_size=None`` and ``batch_size=1`` are the same computation.
+
+        One point per batch leaves the mask always true and the sum over a single row,
+        so no term is reordered and the two agree to roundoff rather than merely to
+        quadrature accuracy. Not bitwise: the batched form still evaluates the integrand
+        under a ``vmap`` of width one, and XLA is free to fuse that differently.
+        """
+        want, _ = self._run(method, i, None)
+        got, _ = self._run(method, i, 1)
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+
+    @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=str)
+    def test_neval_counts_the_padding(self, method, batch_size):
+        """Padded lanes are real calls to the integrand and are reported as such."""
+        _, info = self._run(method, 0, batch_size)
+        expected = 2 + sum(
+            -(-(2 ** (k - 1)) // batch_size) * batch_size
+            for k in range(1, self.DIVMAX + 1)
+        )
+        assert int(info.neval) == expected
+
+    def test_batch_size_is_clipped_to_the_deepest_level(self, method):
+        """No level places more than ``2**(divmax-1)`` points, so nothing above helps.
+
+        Without the clip a generous ``batch_size`` would be padding on every level of a
+        shallow run, and ``neval`` would grow without the run doing any more work.
+        """
+        divmax = 4
+        deepest = 2 ** (divmax - 1)
+        _, clipped = self._run(method, 0, 10**6, divmax=divmax)
+        _, exact = self._run(method, 0, deepest, divmax=divmax)
+        assert int(clipped.neval) == int(exact.neval)
+
+    def test_vector_valued(self, method):
+        """The mask has to broadcast against the integrand's own trailing axes."""
+        fun = lambda x: jnp.array([jnp.sin(x), jnp.cos(x), x**2])  # noqa: E731
+        interval = jnp.array([0.0, 1.0])
+        want, _ = method(fun, interval, divmax=self.DIVMAX, full_output=True)
+        got, _ = method(
+            fun, interval, divmax=self.DIVMAX, full_output=True, batch_size=8
+        )
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=1e-10, atol=1e-12
+        )
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+@pytest.mark.parametrize("batch_size", [0, -1, 2.5], ids=["zero", "negative", "float"])
+def test_bad_batch_size_rejected(method, batch_size):
+    """A batch size that is not a positive integer is a mistake, not a default."""
+    with pytest.raises(ValueError, match="batch_size"):
+        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), batch_size=batch_size)


### PR DESCRIPTION
Adds control over how many integrand evaluations are made in parallel.
  - ``quadgk``, ``quadcc`` and ``quadts`` take a new ``batch_size``, as do the rule
    classes ``GaussKronrodRule``, ``ClenshawCurtisRule`` and ``TanhSinhRule``. It bounds
    how many of the local rule's nodes are evaluated at once, and is clipped at the
    number of nodes. Lowering it bounds the memory an expensive integrand needs, which
    previously could only be done by dropping the order and losing accuracy with it.
  - ``romberg`` and ``rombergts`` take the same argument, where it instead raises the
    width from one point at a time. A level places ``2**(k-1)`` new points, a count only
    known at run time, so the last batch of a level is padded up to a full one and one
    batch shape is traced for every level. ``batch_size=None`` remains the sequential
    loop.