### PR TITLE
More accurate error estimates for Romberg and tanh-sinh quadratures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ v0.3.0
     integrals over ``[a, b]`` that their docstrings describe; they were previously
     scaled by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or
     implementing a custom one.
+  - ``quadts`` and ``TanhSinhRule`` now account for the mass lying beyond their
+    outermost node. A tanh-sinh rule is the trapezoidal rule for an integral over the
+    whole real line in the mapped variable, cut off at a finite range, and the terms
+    past that cutoff carry mass no other weight compensates for. On a bounded integrand
+    the omitted mass is at the level of roundoff and nothing changes; on one singular
+    at an endpoint it can be the whole of the error. Reported ``err`` values and
+    sub-interval counts change on such integrands, and runs that used to report
+    success while missing the requested tolerance now report a non-zero status.
   - ``rombergts``'s reported ``err`` now accounts for the mass its tanh-sinh map leaves
     outside the range it integrates over. That mass is fixed by the map rather than by
     the mesh, so refining converges onto it and the level-to-level movement the estimate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,10 +114,11 @@ v0.3.0
   where it amplifies the error rather than cancelling it. The convergence check and the
   reported ``err`` follow whichever estimate is in use, and the ``table`` returned by
   ``full_output`` then has only its first column filled.
-- ``romberg`` and ``rombergts`` take a new ``initial_points`` argument, default 2. It
-  sets how many points the first refinement level places, where the schedule previously
-  started from just the two endpoints; every later level still doubles the number of new
-  points.
+- ``romberg`` and ``rombergts`` take a new ``divmin`` argument, default 4. It sets what
+  refinement level the solver starts at (number of initial intervals = ``2**divmin``),
+  with the old behavior corresponding to ``divmin=0``. The new default is more efficient
+  on accelerators, and is generally more robust against false early termination, with a
+  small increase in cost on extremely simple integrands.
 - Packaging metadata moved from ``setup.py``/``setup.cfg`` into ``pyproject.toml``.
   Development dependencies are now declared as extras rather than in requirements
   files, so use ``pip install -e ".[dev]"`` (or the narrower ``test``, ``docs``, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ v0.3.0
     integrals over ``[a, b]`` that their docstrings describe; they were previously
     scaled by a factor of ``2 / (b - a)``. Relevant when calling a rule directly or
     implementing a custom one.
+  - ``rombergts``'s reported ``err`` now accounts for the mass its tanh-sinh map leaves
+    outside the range it integrates over. That mass is fixed by the map rather than by
+    the mesh, so refining converges onto it and the level-to-level movement the estimate
+    was built from says nothing about it. Runs that cannot reach the requested tolerance
+    because of it now say so rather than reporting success, and stop once refining can
+    no longer help instead of spending the rest of ``divmax`` budget.
 - **Breaking**: removed ``fixed_quadgk``, ``fixed_quadcc``, and ``fixed_quadts``,
   deprecated since v0.2.2. Use ``GaussKronrodRule``, ``ClenshawCurtisRule``, and
   ``TanhSinhRule`` instead, eg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ v0.3.0
   where it amplifies the error rather than cancelling it. The convergence check and the
   reported ``err`` follow whichever estimate is in use, and the ``table`` returned by
   ``full_output`` then has only its first column filled.
+- ``romberg`` and ``rombergts`` take a new ``initial_points`` argument, default 2. It
+  sets how many points the first refinement level places, where the schedule previously
+  started from just the two endpoints; every later level still doubles the number of new
+  points.
 - Packaging metadata moved from ``setup.py``/``setup.cfg`` into ``pyproject.toml``.
   Development dependencies are now declared as extras rather than in requirements
   files, so use ``pip install -e ".[dev]"`` (or the narrower ``test``, ``docs``, and

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,7 +96,9 @@ can be less efficient, but often still wins on wall time on accelerators.
 refinement level places is only known at run time, so there is no single shape for
 JAX to vectorize over. Setting ``batch_size`` will vectorize over the points on each
 level, but will pad the coarser levels, so the total number of function evaluations
-will slightly increase.
+will slightly increase. Raising ``initial_points`` shifts that trade the other way:
+the first level then places that many points at once, so a run can start wide enough
+to keep an accelerator busy instead of waiting for its levels to grow into it.
 
 In reverse mode there is a second axis to parallelize over, since the sub-intervals of
 the converged subdivision are independent. ``DirectAdjoint`` evaluates them

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,7 +96,7 @@ can be less efficient, but often still wins on wall time on accelerators.
 refinement level places is only known at run time, so there is no single shape for
 JAX to vectorize over. Setting ``batch_size`` will vectorize over the points on each
 level, but will pad the coarser levels, so the total number of function evaluations
-will slightly increase. Raising ``initial_points`` shifts that trade the other way:
+will slightly increase. Raising ``divmin`` shifts that trade the other way:
 the first level then places that many points at once, so a run can start wide enough
 to keep an accelerator busy instead of waiting for its levels to grow into it.
 

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -1197,13 +1197,19 @@ def _adaptive_solve(
         result, abserr, intabs, intmmn = intfun(vfunc, a, b, ())
 
         if extrapolate:
-            # An original sub-interval whose error estimate came back at the saturation
+            # An original sub-interval whose error estimate reached the saturation
             # value (the whole variation of the integrand over it) told the rule
             # nothing about it at all. Those are promoted to the head of the error
             # ordering below, so that the pieces the caller flagged as difficult by
-            # putting a breakpoint at them are the first ones bisected.
+            # putting a breakpoint at them are the first ones bisected. The test is
+            # ``>=`` and not equality because a rule may add to the saturated value,
+            # as a tanh-sinh one does with the mass beyond its outermost node. An
+            # integrand with no variation to saturate against is excluded rather than
+            # counted as unresolved, the estimate then being a roundoff floor sitting
+            # above a variation of zero.
+            variation = _norm(intmmn)
             state["ndin"] = (
-                state["ndin"].at[i].set((abserr == _norm(intmmn)) & (abserr != 0))
+                state["ndin"].at[i].set((abserr >= variation) & (variation != 0))
             )
 
         state["neval"] += 1

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -16,6 +16,40 @@ def _dot(w, f):
     return jnp.sum(w * f.T, axis=-1).T
 
 
+def _endpoint_mass(d0, d1, f0, f1):
+    """Mass of an integrand between an endpoint and the nearest node to it.
+
+    Models ``|f|`` as ``C * d**-p`` in the distance ``d`` from the endpoint, fits ``p``
+    to the two nodes nearest it, and integrates that model over the gap those nodes
+    leave, giving ``f0 * d0 / (1 - p)``.
+
+    An algebraic endpoint singularity is exactly this model, so the fit is the truth
+    there whatever ``p`` is, while the terms of the sum itself have not necessarily
+    started to fall by the time the nodes run out. A singularity mild enough to be
+    integrable always has an integrable model, and one that is not reports an unbounded
+    gap, which is the honest answer for an integrand with no finite integral.
+
+    On a singularity that is not a power of the distance the fitted exponent picks up
+    the local log-log slope, which for the logarithmic case comes out on the
+    conservative side.
+    """
+    ok = (f0 > 0) & (f1 > 0) & (d0 > 0) & (d1 > d0)
+    # The arguments are substituted rather than the result masked afterwards: outside
+    # ``ok`` they are zero or infinite, and the logarithm of either is a nan or carries
+    # an infinite derivative, both of which ``where`` propagates back through the good
+    # branch. The stand-ins are any pair giving an exponent safely below one.
+    #
+    # Taken as a difference of logarithms rather than the logarithm of a ratio, which
+    # is the same quantity but does not overflow when the second node happens to fall
+    # near a zero of the integrand and the ratio of the two is enormous.
+    lf0, lf1 = jnp.log(jnp.where(ok, f0, 2.0)), jnp.log(jnp.where(ok, f1, 1.0))
+    ld0, ld1 = jnp.log(jnp.where(ok, d0, 1.0)), jnp.log(jnp.where(ok, d1, 8.0))
+    exponent = (lf0 - lf1) / (ld1 - ld0)
+    integrable = ok & (exponent < 1)
+    safe = jnp.where(integrable, exponent, 0.0)
+    return jnp.where(integrable, f0 * d0 / (1 - safe), jnp.where(ok, jnp.inf, 0.0))
+
+
 class AbstractQuadratureRule(eqx.Module):
     """Abstract base class for 1D quadrature rules.
 
@@ -196,7 +230,8 @@ class NestedRule(AbstractQuadratureRule):
 
             halflength = (b - a) / 2
             center = (b + a) / 2
-            f: jax.Array = vfun(center + halflength * xh)
+            x = center + halflength * xh
+            f: jax.Array = vfun(x)
             # An integrand that upcasts internally is respected, so the accumulation
             # follows both the limits and the integrand. The weights are cast to the
             # *real* counterpart, which lets a complex integrand promote on its own.
@@ -293,6 +328,12 @@ class NestedRule(AbstractQuadratureRule):
                 jnp.maximum((eps * 50.0) * integral_abs, abserr),
                 abserr,
             )
+            # The nested pair only sees what the nodes span. A rule whose outermost
+            # node stops short of the endpoint has a second, independent shortfall
+            # that no comparison of the two rules can reveal, since both truncate at
+            # the same place, so it is summed rather than max of the two.
+            abserr = abserr + self._truncation(x, f, a, b)
+
             return result, self.norm(abserr), integral_abs, integral_mmn
 
         def truefun():
@@ -323,6 +364,33 @@ class NestedRule(AbstractQuadratureRule):
         f: jax.Array = vfun(center + halflength * xh)
         etype = _real_dtype(jnp.result_type(xtype, f.dtype))
         return _dot(wh_table.astype(etype), f) * halflength
+
+    def _truncation(self, x: jax.Array, f: jax.Array, a: float, b: float) -> jax.Array:
+        """Bound on the mass lying outside the span the rule's nodes cover.
+
+        Internal: the error estimate adds this to the one it gets from the nested
+        pair. Zero here, which is right for an interpolatory rule, whose weights
+        integrate the whole of ``[a, b]`` however its nodes are placed within it.
+        Subclasses that truncate an infinite sum instead override it; see
+        ``TanhSinhRule``.
+
+        Parameters
+        ----------
+        x : jax.Array
+            Abscissae of the high order rule, ordered from ``a`` to ``b``.
+        f : jax.Array
+            Integrand values at those abscissae, leading axis over the nodes.
+        a, b : float
+            Lower and upper limits of integration.
+
+        Returns
+        -------
+        trunc : jax.Array
+            Bound on the omitted mass, shaped like one value of the integrand.
+
+        """
+        del x, a, b
+        return jnp.zeros(f.shape[1:], _real_dtype(f.dtype))
 
     def norm(self, x: jax.Array) -> jax.Array:
         """Norm to use for measuring error for vector valued integrands."""
@@ -452,6 +520,12 @@ class TanhSinhRule(NestedRule):
     trusted on any integrand with structure, including peaked and endpoint-singular ones
     that the other rules handle at much lower order; halving the points of a
     doubly-exponential rule costs far more accuracy than halving a polynomial one.
+
+    The nodes stop short of the endpoints, leaving a sliver of the interval unsampled at
+    each end, and the reported error includes a bound on the mass out there. Comparing
+    the two rules cannot supply it, both of them stopping at the same place. The term is
+    at the level of roundoff on a bounded integrand and can be the whole of the error on
+    one singular at an endpoint.
     """
 
     _order: int
@@ -473,6 +547,55 @@ class TanhSinhRule(NestedRule):
         check_size(batch_size)
         self._batch_size = (
             None if batch_size is None else min(batch_size, len(self._xh))
+        )
+
+    def _truncation(self, x: jax.Array, f: jax.Array, a: float, b: float) -> jax.Array:
+        """Mass beyond the outermost node, charged at both ends.
+
+        The nodes stop at the last one still distinct from the endpoint, so the rule
+        never sees the sliver past it. That shortfall belongs to the map and not to
+        the order: raising the order refines the mesh in ``t`` without extending its
+        range, and the nested pair truncates in both rules at the same place, so the
+        comparison between them says nothing about it. On a bounded integrand it is
+        at the level of roundoff, and on one singular at an endpoint it can be the
+        whole error.
+
+        The pair fitted is taken from the outermost node the rule really used, which
+        is not always the end of the table. On a sub-interval whose endpoints are
+        large relative to its own width the outermost nodes round onto the endpoint
+        itself, an integrand singular there returns a non-finite value, and the
+        wrapper masks it away. Reading that as "no tail" is exactly backwards, it
+        being the case where the tail is largest. Such a node covers no sliver of its
+        own, so the fit steps over it to the first one still distinct from the
+        endpoint.
+
+        Only that case is stepped over, and not every value that came out zero: an
+        integrand that simply vanishes over a stretch of the interval would otherwise
+        send the search into the bulk, where the samples say nothing about the
+        endpoint.
+
+        The node the fit is taken against is the nearest one at a *different*
+        abscissa, which on a narrow sub-interval is not the adjacent one. The
+        clustering is doubly exponential while the representable points near an
+        endpoint are only linearly spaced, so a sub-interval whose width approaches
+        the endpoint's own ulp has many nodes sharing each point. A pair sitting at
+        one distance carries no slope, and taking it would drop the whole tail rather
+        than measure it.
+        """
+        mag = jnp.abs(f)
+        gone = ~jnp.any(mag > 0, axis=tuple(range(1, mag.ndim)))
+        n = x.shape[0]
+        first = jnp.argmin(gone & (x == a))
+        second = jnp.minimum(jnp.sum(x <= x[first]), n - 1)
+        last = n - 1 - jnp.argmin((gone & (x == b))[::-1])
+        penultimate = jnp.maximum(jnp.sum(x < x[last]) - 1, 0)
+        return _endpoint_mass(
+            jnp.abs(x[first] - a), jnp.abs(x[second] - a), mag[first], mag[second]
+        ) + _endpoint_mass(
+            jnp.abs(b - x[last]),
+            jnp.abs(b - x[penultimate]),
+            mag[last],
+            mag[penultimate],
         )
 
     def _nodes_weights(self, xtype) -> tuple[jax.Array, jax.Array, jax.Array]:

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -6,6 +6,7 @@ from functools import partial
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax.typing import ArrayLike
 
 from .adjoint import (
@@ -43,6 +44,7 @@ def romberg(
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
+    initial_points: int = 2,
 ):
     """Romberg integration of a callable function or method.
 
@@ -77,7 +79,7 @@ def romberg(
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at
-        most 2**divmax + 1
+        most (initial_points - 1)*2**divmax + 1
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -106,6 +108,12 @@ def romberg(
         however few points they place; that padding is what keeps a single batch shape
         traced for every level rather than one per level. Clipped to the largest level
         ``divmax`` allows.
+    initial_points : int > 1, optional
+        Number of points on the first refinement level, default 2. Each later level
+        doubles the number of new points, so the grids run ``initial_points``,
+        ``2*initial_points - 1``, and so on. Raising it does the early work of the
+        integration up front, which pays on GPU/TPU where the default
+        schedule spends its first levels evaluating only a handful of points each.
 
     Returns
     -------
@@ -152,9 +160,15 @@ def romberg(
     epsabs = jnp.asarray(epsabs, dtypes.etype)
     epsrel = jnp.asarray(epsrel, dtypes.etype)
     check_size(batch_size)
-    # No level ever places more than `2**(divmax - 1)` new points, so a larger batch
-    # would only ever be padding.
-    batch_size = min(batch_size or 1, 2 ** max(divmax - 1, 0))
+    errorif(
+        not isinstance(initial_points, (int, np.integer)) or initial_points < 2,
+        ValueError,
+        f"initial_points must be an integer >= 2, got {initial_points}",
+    )
+    m = initial_points - 1
+    # No level ever places more than `m * 2**(divmax - 1)` new points, so a larger
+    # batch would only ever be padding.
+    batch_size = min(batch_size or 1, m * 2 ** max(divmax - 1, 0))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -174,6 +188,7 @@ def romberg(
         dtypes.xtype,
         extrapolate,
         batch_size,
+        m,
     )
 
 
@@ -191,6 +206,7 @@ def _romberg(
     xtype,
     extrapolate,
     batch_size,
+    m,
 ):
     """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
     # Closure conversion has to happen on the user's function, before any wrapping:
@@ -207,6 +223,7 @@ def _romberg(
             _norm=_norm,
             extrapolate=extrapolate,
             batch_size=batch_size,
+            m=m,
         ),
         # Romberg has no subdivision to reuse, but it does settle on a number of
         # Richardson levels. Freezing that makes the result a fixed linear functional of
@@ -220,6 +237,7 @@ def _romberg(
             divmax=divmax,
             extrapolate=extrapolate,
             batch_size=batch_size,
+            m=m,
         ),
     )
     y, state = adjoint.quadrature(ops, None, interval, args, consts, epsabs, epsrel, {})
@@ -239,11 +257,13 @@ def _build_tanhsinh(interval, args, consts, *, f_conv, safe=False):
     return wrap_func(fun_m, (), interval_m.dtype, safe=safe), interval_m
 
 
-def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype):
-    """Sum the integrand over the new nodes of one refinement level.
+def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
+    """Sum the integrand over ``npts`` nodes spaced ``step`` multiples of ``h`` apart.
 
-    Level ``k`` adds the ``npts = 2**(k - 1)`` points sitting at odd multiples of ``h``
-    above ``a``, interleaving the nodes the previous levels already placed. ``npts`` is
+    A refinement level adds the ``npts = m * 2**(k - 1)`` points sitting at odd
+    multiples of ``h`` above ``a``, interleaving the nodes the previous levels already
+    placed: ``step=2``, the default. The first level instead sums the interior nodes of
+    the starting grid, consecutive multiples of its own step: ``step=1``. ``npts`` is
     only known at run time, so the points are evaluated in fixed size batches and the
     last batch is padded up to a full one. Padding rather than shaping each level to its
     own point count is what keeps one batch traced for all of them; the cost is that a
@@ -262,7 +282,7 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype):
     def bodyfun(j, s):
         i = j * batch_size + offs
         used = i <= npts
-        x = a + h * (2 * i - 1)
+        x = a + h * (1 + step * (i - 1))
         x = jnp.where(used, x, x[0])
         f: jax.Array = vfunc(x)
         mask = used.reshape((-1,) + (1,) * (f.ndim - 1))
@@ -283,6 +303,7 @@ def _romberg_solve(
     _norm,
     extrapolate=True,
     batch_size=1,
+    m=1,
 ):
     """Run the refinement loop, with Richardson extrapolation if it is switched on.
 
@@ -306,9 +327,12 @@ def _romberg_solve(
     best = (lambda res, k: res[k, k]) if extrapolate else (lambda res, k: res[k, 0])
 
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    # The trapezoid rule at one interval.
-    result = result.at[0, 0].set((b - a) / 2 * (vfunc(a) + vfunc(b)))
-    neval = 2
+    # The composite trapezoid rule over the m intervals of the first level: interior
+    # nodes summed in batches, endpoints evaluated directly at half weight.
+    h0 = (b - a) / m
+    s, nbatch = _level_sum(vfunc, a, h0, m - 1, batch_size, f.shape, f.dtype, step=1)
+    result = result.at[0, 0].set(h0 * (s + (vfunc(a) + vfunc(b)) / 2))
+    neval = 2 + nbatch * batch_size
     # Explicitly typed rather than left a weak python float: this is a loop carry, and
     # has to match what `_norm` writes back into it. Real, because the error in a
     # complex valued integral is still real.
@@ -324,17 +348,19 @@ def _romberg_solve(
     def nloop(state):
         # loop over outer number of subdivisions
         result, n, neval, err = state
-        h = (b - a) / 2**n
-        s, nbatch = _level_sum(vfunc, a, h, (2**n) // 2, batch_size, f.shape, f.dtype)
+        h = h0 / 2**n
+        s, nbatch = _level_sum(
+            vfunc, a, h, (m * 2**n) // 2, batch_size, f.shape, f.dtype
+        )
         result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
         # The padded lanes of the last batch are evaluations of the integrand like any
         # other, so they are counted here even though they do not reach the sum.
         neval += nbatch * batch_size
 
-        def mloop(m, result):
+        def mloop(col, result):
             # richardson extrapolation
-            temp = 1 / (4.0**m - 1.0) * (result[n, m - 1] - result[n - 1, m - 1])
-            result = result.at[n, m].set(result[n, m - 1] + temp)
+            temp = 1 / (4.0**col - 1.0) * (result[n, col - 1] - result[n - 1, col - 1])
+            result = result.at[n, col].set(result[n, col - 1] + temp)
             return result
 
         if extrapolate:
@@ -357,7 +383,7 @@ def _romberg_solve(
 
 
 def _romberg_levels(
-    rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=True, batch_size=1
+    rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=True, batch_size=1, m=1
 ):
     """Evaluate the table at a fixed number of levels.
 
@@ -371,17 +397,20 @@ def _romberg_levels(
     vfunc = wrap_func(vfunc, (), interval.dtype)  # see ``_romberg_solve``
     f = jax.eval_shape(vfunc, (a + b) / 2)
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    # The trapezoid rule at one interval.
-    result = result.at[0, 0].set((b - a) / 2 * (vfunc(a) + vfunc(b)))
+    # The composite trapezoid rule over the m intervals of the first level, as in
+    # ``_romberg_solve``.
+    h0 = (b - a) / m
+    s, _ = _level_sum(vfunc, a, h0, m - 1, batch_size, f.shape, f.dtype, step=1)
+    result = result.at[0, 0].set(h0 * (s + (vfunc(a) + vfunc(b)) / 2))
 
     def nloop(k, result):
-        h = (b - a) / 2**k
-        s, _ = _level_sum(vfunc, a, h, (2**k) // 2, batch_size, f.shape, f.dtype)
+        h = h0 / 2**k
+        s, _ = _level_sum(vfunc, a, h, (m * 2**k) // 2, batch_size, f.shape, f.dtype)
         result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
 
-        def mloop(m, result):
-            temp = 1 / (4.0**m - 1.0) * (result[k, m - 1] - result[k - 1, m - 1])
-            return result.at[k, m].set(result[k, m - 1] + temp)
+        def mloop(col, result):
+            temp = 1 / (4.0**col - 1.0) * (result[k, col - 1] - result[k - 1, col - 1])
+            return result.at[k, col].set(result[k, col - 1] + temp)
 
         if not extrapolate:
             return result
@@ -404,6 +433,7 @@ def rombergts(
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
+    initial_points: int = 2,
 ):
     """Romberg integration with tanh-sinh (aka double exponential) transformation.
 
@@ -438,7 +468,7 @@ def rombergts(
     divmax : int, optional
         Maximum order of extrapolation. Default is 20.
         Total number of function evaluations will be at
-        most 2**divmax + 1
+        most (initial_points - 1)*2**divmax + 1
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -467,7 +497,12 @@ def rombergts(
         however few points they place; that padding is what keeps a single batch shape
         traced for every level rather than one per level. Clipped to the largest level
         ``divmax`` allows.
-
+    initial_points : int > 1, optional
+        Number of points on the first refinement level, default 2. Each later level
+        doubles the number of new points, so the grids run ``initial_points``,
+        ``2*initial_points - 1``, and so on. Raising it does the early work of the
+        integration up front, which pays on GPU/TPU where the default schedule spends
+        its first levels evaluating only a handful of points each.
 
     Returns
     -------
@@ -514,9 +549,15 @@ def rombergts(
     epsabs = jnp.asarray(epsabs, dtypes.etype)
     epsrel = jnp.asarray(epsrel, dtypes.etype)
     check_size(batch_size)
-    # No level ever places more than `2**(divmax - 1)` new points, so a larger batch
-    # would only ever be padding.
-    batch_size = min(batch_size or 1, 2 ** max(divmax - 1, 0))
+    errorif(
+        not isinstance(initial_points, (int, np.integer)) or initial_points < 2,
+        ValueError,
+        f"initial_points must be an integer >= 2, got {initial_points}",
+    )
+    m = initial_points - 1
+    # No level ever places more than `m * 2**(divmax - 1)` new points, so a larger
+    # batch would only ever be padding.
+    batch_size = min(batch_size or 1, m * 2 ** max(divmax - 1, 0))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -536,4 +577,5 @@ def rombergts(
         dtypes.xtype,
         extrapolate,
         batch_size,
+        m,
     )

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -228,8 +228,14 @@ def _romberg(
     extrapolate,
     batch_size,
     divmin,
+    truncation=None,
 ):
-    """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
+    """Shared driver for ``romberg`` and ``rombergts``.
+
+    They differ in ``build``, and in whether that map truncates: ``truncation``
+    estimates the mass left outside the range the solve integrates over, and is unset
+    for the maps that leave none.
+    """
     # Closure conversion has to happen on the user's function, before any wrapping:
     # once a transformed integrand crosses a filter_jit boundary its leaves become
     # tracers that closure_convert cannot hoist.
@@ -245,6 +251,7 @@ def _romberg(
             extrapolate=extrapolate,
             batch_size=batch_size,
             divmin=divmin,
+            truncation=truncation,
         ),
         # Romberg has no subdivision to reuse, but it does settle on a number of
         # Richardson levels. Freezing that makes the result a fixed linear functional of
@@ -278,6 +285,20 @@ def _build_tanhsinh(interval, args, consts, *, f_conv, safe=False):
     return wrap_func(fun_m, (), interval_m.dtype, safe=safe), interval_m
 
 
+def _outermost(i, f, npts):
+    """Magnitude of the first and last of the points a sweep places, as a stacked pair.
+
+    The two sit nearest the ends of the range, which is what the truncation estimate
+    reads. Picked out of whichever batch happens to hold them rather than evaluated
+    again; the lanes that hold neither contribute zero to the sum over batches.
+    """
+    keep = lambda which: jnp.sum(
+        jnp.where((i == which).reshape((-1,) + (1,) * (f.ndim - 1)), jnp.abs(f), 0),
+        axis=0,
+    )
+    return jnp.stack([keep(1), keep(npts)])
+
+
 def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
     """Sum the integrand over ``npts`` nodes spaced ``step`` multiples of ``h`` apart.
 
@@ -297,16 +318,17 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
 
     ``vfunc`` takes a whole batch of abscissae; the callers wrap it to guarantee that.
 
-    Returns the sum, the sum of ``abs`` of the same values, and the number of batches.
-    The second is what the error estimate's roundoff floor is built from; it needs no
-    extra evaluations, so it is always accumulated and left to be eliminated as dead
-    code on the paths that do not read it.
+    Returns the sum, the sum of ``abs`` of the same values, the magnitude of the
+    outermost new node either side, and the number of batches.
+    The middle two are what the error estimate's roundoff floor and its truncation term
+    are built from; neither needs extra evaluations, so both are always accumulated and
+    left to be eliminated as dead code on the paths that do not read them.
     """
     nbatch = (npts + batch_size - 1) // batch_size
     offs = jnp.arange(1, batch_size + 1)
 
     def bodyfun(j, carry):
-        s, sabs = carry
+        s, sabs, ends = carry
         i = j * batch_size + offs
         used = i <= npts
         x = a + h * (1 + step * (i - 1))
@@ -314,11 +336,16 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
         f: jax.Array = vfunc(x)
         mask = used.reshape((-1,) + (1,) * (f.ndim - 1))
         f = jnp.where(mask, f, 0)
-        return s + jnp.sum(f, axis=0), sabs + jnp.sum(jnp.abs(f), axis=0)
+        return (
+            s + jnp.sum(f, axis=0),
+            sabs + jnp.sum(jnp.abs(f), axis=0),
+            ends + _outermost(i, f, npts),
+        )
 
-    init = (jnp.zeros(shape, dtype), jnp.zeros(shape, _real_dtype(dtype)))
-    s, sabs = jax.lax.fori_loop(0, nbatch, bodyfun, init)
-    return s, sabs, nbatch
+    rzero = jnp.zeros(shape, _real_dtype(dtype))
+    init = (jnp.zeros(shape, dtype), rzero, jnp.stack([rzero, rzero]))
+    s, sabs, ends = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    return s, sabs, ends, nbatch
 
 
 def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
@@ -337,14 +364,24 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
     where a run started beyond the order its sums are accumulated in.
 
     Returns the rule indexed by row, the same rule applied to ``abs`` of the integrand
-    on the finest of these grids, and the number of evaluations spent. Only the finest
-    row of the second is needed, since the refinement loop carries it forward by the
-    same halving recursion.
+    on the finest of these grids, the magnitude of the integrand at the two endpoints
+    and at the outermost interior node either side, and the number of evaluations spent.
+    Only the finest row of the second is needed, since the refinement loop carries it
+    forward by the same halving recursion. The last two are handed back rather than
+    evaluated again because the truncation estimate reads exactly those nodes; see
+    ``_tanhsinh_truncation``.
     """
     fa, fb = vfunc(a), vfunc(b)
+    edges = jnp.stack([jnp.abs(fa), jnp.abs(fb)])
     fab = (jnp.abs(fa) + jnp.abs(fb)) / 2
     if divmin == 0:
-        return jnp.stack([(b - a) * (fa + fb) / 2]), (b - a) * fab, 2
+        return (
+            jnp.stack([(b - a) * (fa + fb) / 2]),
+            (b - a) * fab,
+            edges,
+            jnp.zeros_like(edges),
+            2,
+        )
 
     npts = 2**divmin - 1  # interior points of the finest of these grids
     h = (b - a) / 2**divmin
@@ -352,7 +389,7 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
     offs = jnp.arange(1, batch_size + 1)
 
     def bodyfun(k, carry):
-        s, sabs = carry
+        s, sabs, ends = carry
         i = k * batch_size + offs
         used = i <= npts
         x = a + h * i
@@ -371,16 +408,21 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
             new = new.reshape((-1,) + (1,) * (fx.ndim - 1))
             added.append(jnp.sum(jnp.where(new, fx, 0), axis=0))
         # `abs` needs no such split: only the finest grid's value is ever read.
-        return s + jnp.stack(added), sabs + jnp.sum(jnp.abs(fx), axis=0)
+        return (
+            s + jnp.stack(added),
+            sabs + jnp.sum(jnp.abs(fx), axis=0),
+            ends + _outermost(i, fx, npts),
+        )
 
-    init = (jnp.zeros((divmin, *shape), dtype), jnp.zeros(shape, _real_dtype(dtype)))
-    added, sabs = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    rzero = jnp.zeros(shape, _real_dtype(dtype))
+    init = (jnp.zeros((divmin, *shape), dtype), rzero, jnp.stack([rzero, rzero]))
+    added, sabs, outer = jax.lax.fori_loop(0, nbatch, bodyfun, init)
 
     col0 = [(b - a) * (fa + fb) / 2]
     for j in range(1, divmin + 1):
         col0.append(0.5 * col0[j - 1] + ((b - a) / 2**j) * added[j - 1])
     resabs = ((b - a) / 2**divmin) * (sabs + fab)
-    return jnp.stack(col0), resabs, 2 + nbatch * batch_size
+    return jnp.stack(col0), resabs, edges, outer, 2 + nbatch * batch_size
 
 
 def _extrapolate_row(result, n, extrapolate):
@@ -415,7 +457,15 @@ _TAIL_CAP = 0.9
 _ANOMALY = 0.1
 
 
-def _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow):
+def _romberg_err(
+    d: jax.Array,
+    dprev: jax.Array,
+    dprev2: jax.Array,
+    resabs: jax.Array,
+    _norm: Callable,
+    eps: float,
+    uflow: float,
+):
     """Estimate the error in the level whose estimate moved by ``d``.
 
     ``d``, ``dprev`` and ``dprev2`` are the last three level-to-level movements of the
@@ -472,6 +522,39 @@ def _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow):
     )
 
 
+def _tanhsinh_truncation(edges, outer, rtype, _norm):
+    """Estimate the mass the tanh-sinh map leaves outside the range it is truncated to.
+
+    ``rombergts`` integrates over ``[-tmax, tmax]``, and the substitution is a change of
+    variable, so what it omits in ``t`` is exactly the sliver in ``x`` beyond the
+    outermost node. That is a shortfall of the map rather than of the mesh: refining
+    converges onto it, so the movement between levels says nothing about it at all.
+    Left out of the estimate it is the one error a run can have while reporting success,
+    which is why it is charged whatever the table is doing.
+
+    Its size is read off the outermost term of the sum, which is the standard tanh-sinh
+    indicator (``d4`` of [1]_ section 5). Past the cutoff the weight falls double
+    exponentially, so the last term bounds what is left of the sum wherever the
+    integrand is not itself growing faster than that.
+
+    ``edges`` is the term at the cutoff and ``outer`` the term at the outermost node any
+    level has placed and got a value from. The cutoff is preferred, and the fallback is
+    what makes the estimate work where it is unusable: on an interval whose endpoints
+    are large relative to its width the outermost nodes round onto the endpoint itself,
+    and an integrand singular there returns a non-finite value that the wrapper masks
+    away. Reading that as "no tail" is exactly backwards, it being the case where the
+    tail is largest. Both ends are omitted, so both are charged.
+
+    References
+    ----------
+    .. [1] Bailey, Jeyabalan and Li, "A comparison of three high-precision quadrature
+       schemes", Experimental Mathematics 14.3 (2005).
+
+    """
+    term = jnp.where(edges > 0, edges, outer).astype(rtype)
+    return _norm(term[0] + term[1])
+
+
 def _romberg_solve(
     rule,
     vfunc,
@@ -485,6 +568,7 @@ def _romberg_solve(
     extrapolate=True,
     batch_size=1,
     divmin=4,
+    truncation=None,
 ):
     """Run the refinement loop, with Richardson extrapolation if it is switched on.
 
@@ -513,10 +597,40 @@ def _romberg_solve(
     best = (lambda res, k: res[k, k]) if extrapolate else (lambda res, k: res[k, 0])
 
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    col0, resabs, neval = _initial_rows(
+    col0, resabs, edges, outer, neval = _initial_rows(
         vfunc, a, b, divmin, batch_size, f.shape, f.dtype
     )
     result = result.at[: divmin + 1, 0].set(col0)
+
+    def trunc_of(outer):
+        """What the map leaves outside the range the solve integrates over.
+
+        Zero for the variants whose map truncates nothing, which is every one but
+        tanh-sinh.
+        """
+        if truncation is None:
+            return jnp.array(0.0, rtype)
+        return truncation(edges, outer, rtype, _norm)
+
+    def keep_outer(outer, ends):
+        """Take the newer pair of outermost nodes, for whichever end got a value.
+
+        Each level places its outermost nodes closer to the ends than the last did, so a
+        value from this level supersedes the one carried. A zero does not: it is a node
+        that has rounded onto the endpoint and been masked away, and the last node that
+        resolved remains the best that end has to say.
+        """
+        return jnp.where(ends > 0, ends, outer)
+
+    def total_err(d, dprev, dprev2, resabs, outer):
+        """The error in the current estimate.
+
+        What the mesh has left to give, plus what the map never had. The two are
+        independent shortfalls, so they add.
+        """
+        return _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow) + trunc_of(
+            outer
+        )
 
     def advance(result, n, yprev):
         """Extrapolate row ``n`` and measure how far its estimate moved."""
@@ -550,38 +664,52 @@ def _romberg_solve(
     result, y, d, dprev, dprev2 = jax.lax.fori_loop(
         1, divmin + 1, initloop, (result, result[0, 0], zero, zero, zero)
     )
-    err = _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow)
+    err = total_err(d, dprev, dprev2, resabs, outer)
     # A run given no rows to compare has no estimate at all, whatever the table says:
     # with no movements the formula would return its roundoff floor, which reads as
     # convergence on the strength of a single trapezoidal value.
     if divmin < 1:
         err = jnp.array(jnp.inf, rtype)
 
-    state = (result, divmin + 1, neval, err, y, resabs, d, dprev)
+    state = (result, divmin + 1, neval, err, y, resabs, d, dprev, outer)
 
     def ncond(state):
-        result, n, neval, err, y, resabs, dprev, dprev2 = state
+        result, n, neval, err, y, resabs, dprev, dprev2, outer = state
         # `n` is the row about to be computed, so `n - 1` rows are complete and `y` is
         # the value read off the last of them.
-        return (n < divmax + 1) & unconverged(y, err, n - 1)
+        tol = jnp.maximum(epsabs, epsrel * _norm(y))
+        trunc = trunc_of(outer)
+        # Refining is pointless once the mesh has converged onto a floor the map itself
+        # holds above the tolerance: every further level doubles the evaluations while
+        # the reported error stays where it is. Since the two shares are added,
+        # `err <= 2 * trunc` is the mesh's own share having fallen to that floor. The
+        # run still ends unconverged, which is the honest outcome; this only declines to
+        # spend the rest of `divmax` reaching it.
+        # A zero tolerance is not a threshold that can be missed, it is a request to
+        # refine as far as `divmax` allows, so it is never read as unreachable.
+        hopeless = (
+            (tol > 0) & (trunc > tol) & (err <= 2 * trunc) & (n - 1 >= _MIN_LEVELS)
+        )
+        return (n < divmax + 1) & unconverged(y, err, n - 1) & ~hopeless
 
     def nloop(state):
         # loop over outer number of subdivisions
-        result, n, neval, err, yprev, resabs, dprev, dprev2 = state
+        result, n, neval, err, yprev, resabs, dprev, dprev2, outer = state
         h = (b - a) / 2**n
-        s, sabs, nbatch = _level_sum(
+        s, sabs, ends, nbatch = _level_sum(
             vfunc, a, h, 2 ** (n - 1), batch_size, f.shape, f.dtype
         )
         result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
         resabs = 0.5 * resabs + h * sabs
+        outer = keep_outer(outer, ends)
         # The padded lanes of the last batch are evaluations of the integrand like any
         # other, so they are counted here even though they do not reach the sum.
         neval += nbatch * batch_size
         result, y, d = advance(result, n, yprev)
-        err = _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow)
-        return result, n + 1, neval, err, y, resabs, d, dprev
+        err = total_err(d, dprev, dprev2, resabs, outer)
+        return result, n + 1, neval, err, y, resabs, d, dprev, outer
 
-    result, n, neval, err, y, resabs, dprev, dprev2 = bounded_while_loop(
+    result, n, neval, err, y, resabs, dprev, dprev2, outer = bounded_while_loop(
         ncond, nloop, state, max(divmax - divmin, 0) + 1
     )
 
@@ -620,7 +748,7 @@ def _romberg_levels(
     vfunc = wrap_func(vfunc, (), interval.dtype)  # see ``_romberg_solve``
     f = jax.eval_shape(vfunc, (a + b) / 2)
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    col0, _, _ = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
+    col0, *_ = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
     result = result.at[: divmin + 1, 0].set(col0)
     result = jax.lax.fori_loop(
         1, divmin + 1, lambda k, res: _extrapolate_row(res, k, extrapolate), result
@@ -628,7 +756,7 @@ def _romberg_levels(
 
     def nloop(k, result):
         h = (b - a) / 2**k
-        s, _, _ = _level_sum(vfunc, a, h, 2 ** (k - 1), batch_size, f.shape, f.dtype)
+        s, *_ = _level_sum(vfunc, a, h, 2 ** (k - 1), batch_size, f.shape, f.dtype)
         result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
         return _extrapolate_row(result, k, extrapolate)
 
@@ -810,4 +938,5 @@ def rombergts(
         extrapolate,
         batch_size,
         divmin,
+        truncation=_tanhsinh_truncation,
     )

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -71,9 +71,11 @@ def romberg(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float
-        Absolute and relative tolerances. If I1 and I2 are two successive approximations
-        to the integral, algorithm terminates when abs(I1-I2) < max(epsabs,
-        epsrel*|I2|). Default is the square root of the machine precision of the working
+        Absolute and relative tolerances. The algorithm terminates once its estimate of
+        the error in the current approximation ``I`` falls below ``max(epsabs,
+        epsrel*|I|)``, which takes at least two refinement levels whatever the tolerance
+        and ``divmin``, since the first level's estimate has no earlier one to be judged
+        against. Default is the square root of the machine precision of the working
         dtype, ie of `interval`, or of the integrand's own dtype if that is the coarser
         of the two.
     divmax : int, optional
@@ -129,7 +131,10 @@ def romberg(
     info : QuadratureInfo
         Named tuple with the following fields:
 
-        * err : (float) Estimate of the error in the approximation.
+        * err : (float) Estimate of the error in the approximation. Built from how far
+          the estimate moved over the last few refinement levels rather than over the
+          last one alone, plus the tail that movement's own contraction rate implies,
+          and floored at the precision the integrand can be summed to.
         * neval : (int) Total number of function evaluations.
         * status : (int) Flag indicating reason for termination. status of 0 means
           normal termination, any other value indicates a possible error. A human
@@ -291,20 +296,29 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
     and masking that out of the sum afterwards still leaves a NaN in its derivative.
 
     ``vfunc`` takes a whole batch of abscissae; the callers wrap it to guarantee that.
+
+    Returns the sum, the sum of ``abs`` of the same values, and the number of batches.
+    The second is what the error estimate's roundoff floor is built from; it needs no
+    extra evaluations, so it is always accumulated and left to be eliminated as dead
+    code on the paths that do not read it.
     """
     nbatch = (npts + batch_size - 1) // batch_size
     offs = jnp.arange(1, batch_size + 1)
 
-    def bodyfun(j, s):
+    def bodyfun(j, carry):
+        s, sabs = carry
         i = j * batch_size + offs
         used = i <= npts
         x = a + h * (1 + step * (i - 1))
         x = jnp.where(used, x, x[0])
         f: jax.Array = vfunc(x)
         mask = used.reshape((-1,) + (1,) * (f.ndim - 1))
-        return s + jnp.sum(jnp.where(mask, f, 0), axis=0)
+        f = jnp.where(mask, f, 0)
+        return s + jnp.sum(f, axis=0), sabs + jnp.sum(jnp.abs(f), axis=0)
 
-    return jax.lax.fori_loop(0, nbatch, bodyfun, jnp.zeros(shape, dtype)), nbatch
+    init = (jnp.zeros(shape, dtype), jnp.zeros(shape, _real_dtype(dtype)))
+    s, sabs = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    return s, sabs, nbatch
 
 
 def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
@@ -322,18 +336,23 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
     rather than by summing each grid outright, so that the table does not depend on
     where a run started beyond the order its sums are accumulated in.
 
-    Returns the rule indexed by row, and the number of evaluations spent.
+    Returns the rule indexed by row, the same rule applied to ``abs`` of the integrand
+    on the finest of these grids, and the number of evaluations spent. Only the finest
+    row of the second is needed, since the refinement loop carries it forward by the
+    same halving recursion.
     """
     fa, fb = vfunc(a), vfunc(b)
+    fab = (jnp.abs(fa) + jnp.abs(fb)) / 2
     if divmin == 0:
-        return jnp.stack([(b - a) * (fa + fb) / 2]), 2
+        return jnp.stack([(b - a) * (fa + fb) / 2]), (b - a) * fab, 2
 
     npts = 2**divmin - 1  # interior points of the finest of these grids
     h = (b - a) / 2**divmin
     nbatch = (npts + batch_size - 1) // batch_size
     offs = jnp.arange(1, batch_size + 1)
 
-    def bodyfun(k, s):
+    def bodyfun(k, carry):
+        s, sabs = carry
         i = k * batch_size + offs
         used = i <= npts
         x = a + h * i
@@ -351,14 +370,17 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
             new = ((i % stride) == 0) & ((i % (2 * stride)) != 0)
             new = new.reshape((-1,) + (1,) * (fx.ndim - 1))
             added.append(jnp.sum(jnp.where(new, fx, 0), axis=0))
-        return s + jnp.stack(added)
+        # `abs` needs no such split: only the finest grid's value is ever read.
+        return s + jnp.stack(added), sabs + jnp.sum(jnp.abs(fx), axis=0)
 
-    added = jax.lax.fori_loop(0, nbatch, bodyfun, jnp.zeros((divmin, *shape), dtype))
+    init = (jnp.zeros((divmin, *shape), dtype), jnp.zeros(shape, _real_dtype(dtype)))
+    added, sabs = jax.lax.fori_loop(0, nbatch, bodyfun, init)
 
     col0 = [(b - a) * (fa + fb) / 2]
     for j in range(1, divmin + 1):
         col0.append(0.5 * col0[j - 1] + ((b - a) / 2**j) * added[j - 1])
-    return jnp.stack(col0), 2 + nbatch * batch_size
+    resabs = ((b - a) / 2**divmin) * (sabs + fab)
+    return jnp.stack(col0), resabs, 2 + nbatch * batch_size
 
 
 def _extrapolate_row(result, n, extrapolate):
@@ -372,6 +394,82 @@ def _extrapolate_row(result, n, extrapolate):
         return result.at[n, col].set(result[n, col - 1] + temp)
 
     return jax.lax.fori_loop(1, n + 1, mloop, result)
+
+
+# Two levels have to be complete before convergence may be declared, because the first
+# movement has nothing to be judged against. Without it the level 0 and level 1
+# estimates agreeing by accident - because a narrow feature falls between the three
+# points those levels use, or because the integrand is non-finite at an endpoint and
+# both levels inherit the same substituted value - is read as convergence, and the
+# routine returns an answer it never sampled with a status of 0. A ``divmin`` of 2 or
+# more satisfies this on its own.
+_MIN_LEVELS = 2
+# Largest contraction ratio the tail term will extrapolate from, so a sequence that has
+# stopped contracting is charged a bounded penalty - here 9x the last movement - rather
+# than the infinite one the geometric series would give at a ratio of 1.
+_TAIL_CAP = 0.9
+# How far below the previous contraction ratio this one has to fall for the movement to
+# count as an anomaly rather than a trend. Loose enough that a sequence whose ratio
+# improves from level to level, which is what Richardson does on a smooth integrand, is
+# still read as a trend.
+_ANOMALY = 0.1
+
+
+def _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow):
+    """Estimate the error in the level whose estimate moved by ``d``.
+
+    ``d``, ``dprev`` and ``dprev2`` are the last three level-to-level movements of the
+    reported estimate, newest first, normed to scalars; the two older ones are zero
+    before there is any history. ``resabs`` is the same rule applied to ``abs`` of the
+    integrand.
+
+    The movement between successive levels measures how far the estimate last *went*,
+    which is only a proxy for how far it still has *to go*. Two things make it a poor
+    one, and each gets a correction:
+
+    - Two levels can land close together on the way past a value neither has resolved,
+      which reads as convergence but is a coincidence. What distinguishes the two is
+      whether the movement follows the trend: a sequence in the regime its error
+      expansion describes contracts by a roughly steady ratio, or by an improving one,
+      whereas a coincidence shows up as a single ratio far below the one before it.
+      Where the ratio collapses like that, the largest of the last three movements is
+      reported instead, so that one lucky near-repeat cannot end the run.
+    - Even a well behaved movement understates the total remaining, which is the whole
+      geometric tail rather than its first term. Adding ``d * r / (1 - r)`` charges that
+      tail: negligible for a rapidly contracting sequence, and growing without bound as
+      the contraction stalls, which is where the movement alone is least informative.
+      For the trapezoidal column, whose ratio settles at 1/4, the two together come to
+      ``4/3`` of the movement, which is that column's error exactly.
+
+    Finally the result is floored at ``50 * eps * resabs``, since no estimate is
+    meaningful below the noise of evaluating and summing the integrand.
+    """
+    # Substituted rather than masked, in both ratios: the denominators are exactly zero
+    # both before there is any history and whenever two levels agree to the last bit,
+    # and dividing by them would put a NaN into the estimate by way of `inf * 0`.
+    # A missing `dprev` is read as no contraction, and a missing `dprev2` as no trend to
+    # depart from, which are the conservative readings of each.
+    ratio = jnp.where(dprev > 0, d / jnp.where(dprev > 0, dprev, 1), _TAIL_CAP)
+    prev_ratio = jnp.where(
+        dprev2 > 0, dprev / jnp.where(dprev2 > 0, dprev2, 1), jnp.inf
+    )
+    anomaly = ratio < _ANOMALY * prev_ratio
+    err = jnp.where(anomaly, jnp.maximum(d, jnp.maximum(dprev, dprev2)), d)
+
+    ratio = jnp.minimum(ratio, _TAIL_CAP)
+    err = err + d * ratio / (1 - ratio)
+
+    # The floor covers the conditioning of the integrand rather than the summation:
+    # abscissae carry `~eps*|x|`, which the integrand amplifies by `|f'|`. 50 is
+    # QUADPACK's constant for the same quantity. The guard keeps the product from
+    # underflowing to zero, which would make the floor a no-op precisely where the
+    # integrand is smallest.
+    absnorm = _norm(resabs)
+    return jnp.where(
+        absnorm > uflow / (50.0 * eps),
+        jnp.maximum((50.0 * eps) * absnorm, err),
+        err,
+    )
 
 
 def _romberg_solve(
@@ -404,6 +502,10 @@ def _romberg_solve(
     vfunc = wrap_func(vfunc, (), interval.dtype)
     f = jax.eval_shape(vfunc, (a + b) / 2)
     rtype = _real_dtype(f.dtype)
+    # Compile time constants, as python floats rather than arrays of the working dtype:
+    # forming `uflow / (50 * eps)` in half precision is a needless underflow risk.
+    eps = float(jnp.finfo(rtype).eps)
+    uflow = float(jnp.finfo(rtype).tiny)
 
     # Which entry of row `k` is the estimate. Richardson's is the diagonal, having
     # applied `k` rounds of extrapolation to the trapezoidal values in column 0; without
@@ -411,7 +513,9 @@ def _romberg_solve(
     best = (lambda res, k: res[k, k]) if extrapolate else (lambda res, k: res[k, 0])
 
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    col0, neval = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
+    col0, resabs, neval = _initial_rows(
+        vfunc, a, b, divmin, batch_size, f.shape, f.dtype
+    )
     result = result.at[: divmin + 1, 0].set(col0)
 
     def advance(result, n, yprev):
@@ -420,49 +524,68 @@ def _romberg_solve(
         y = best(result, n)
         return result, y, _norm(y - yprev)
 
+    def unconverged(y, err, nlevels):
+        """Whether the run has to keep going.
+
+        Either the estimate is still above tolerance, or there are not yet enough
+        levels for it to rest on; see ``_MIN_LEVELS``.
+        """
+        return (err > jnp.maximum(epsabs, epsrel * _norm(y))) | (nlevels < _MIN_LEVELS)
+
     # Rows 1 through `divmin` came out of the sweep above, so they are processed
     # unconditionally: their evaluations are already spent, and running them is what
-    # gives the run a history before the first refinement rather than after it.
+    # gives the run a history before the first refinement rather than after it. Only
+    # the movements are kept, since the error estimate reads the last three of them and
+    # anything it would have said about an intermediate row is never looked at.
     def initloop(k, carry):
-        result, yprev, _ = carry
-        return advance(result, k, yprev)
+        result, yprev, d, dprev, _ = carry
+        result, y, dnew = advance(result, k, yprev)
+        return result, y, dnew, d, dprev
 
-    # Explicitly typed rather than left a weak python float: this is a loop carry, and
-    # has to match what `_norm` writes back into it. Real, because the error in a
-    # complex valued integral is still real.
-    err = jnp.array(jnp.inf, rtype)
-    result, y, err = jax.lax.fori_loop(
-        1, divmin + 1, initloop, (result, result[0, 0], err)
+    # Explicitly typed rather than left weak python floats: these are loop carries, and
+    # have to match what `_norm` writes back into them. Real, because the error in a
+    # complex valued integral is still real. The movements start at zero, which
+    # `_romberg_err` reads as "no history yet".
+    zero = jnp.array(0.0, rtype)
+    result, y, d, dprev, dprev2 = jax.lax.fori_loop(
+        1, divmin + 1, initloop, (result, result[0, 0], zero, zero, zero)
     )
-    # A run given no rows to compare has no estimate at all, whatever the table says.
+    err = _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow)
+    # A run given no rows to compare has no estimate at all, whatever the table says:
+    # with no movements the formula would return its roundoff floor, which reads as
+    # convergence on the strength of a single trapezoidal value.
     if divmin < 1:
         err = jnp.array(jnp.inf, rtype)
 
-    state = (result, divmin + 1, neval, err, y)
+    state = (result, divmin + 1, neval, err, y, resabs, d, dprev)
 
     def ncond(state):
-        result, n, neval, err, y = state
+        result, n, neval, err, y, resabs, dprev, dprev2 = state
         # `n` is the row about to be computed, so `n - 1` rows are complete and `y` is
         # the value read off the last of them.
-        return (n < divmax + 1) & (err > jnp.maximum(epsabs, epsrel * _norm(y)))
+        return (n < divmax + 1) & unconverged(y, err, n - 1)
 
     def nloop(state):
         # loop over outer number of subdivisions
-        result, n, neval, err, yprev = state
+        result, n, neval, err, yprev, resabs, dprev, dprev2 = state
         h = (b - a) / 2**n
-        s, nbatch = _level_sum(vfunc, a, h, 2 ** (n - 1), batch_size, f.shape, f.dtype)
+        s, sabs, nbatch = _level_sum(
+            vfunc, a, h, 2 ** (n - 1), batch_size, f.shape, f.dtype
+        )
         result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
+        resabs = 0.5 * resabs + h * sabs
         # The padded lanes of the last batch are evaluations of the integrand like any
         # other, so they are counted here even though they do not reach the sum.
         neval += nbatch * batch_size
-        result, y, err = advance(result, n, yprev)
-        return result, n + 1, neval, err, y
+        result, y, d = advance(result, n, yprev)
+        err = _romberg_err(d, dprev, dprev2, resabs, _norm, eps, uflow)
+        return result, n + 1, neval, err, y, resabs, d, dprev
 
-    result, n, neval, err, y = bounded_while_loop(
+    result, n, neval, err, y, resabs, dprev, dprev2 = bounded_while_loop(
         ncond, nloop, state, max(divmax - divmin, 0) + 1
     )
 
-    status = 2 * (err > jnp.maximum(epsabs, epsrel * _norm(y)))
+    status = 2 * unconverged(y, err, n - 1)
     state = {
         "table": result,
         "err_sum": err,
@@ -497,7 +620,7 @@ def _romberg_levels(
     vfunc = wrap_func(vfunc, (), interval.dtype)  # see ``_romberg_solve``
     f = jax.eval_shape(vfunc, (a + b) / 2)
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    col0, _ = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
+    col0, _, _ = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
     result = result.at[: divmin + 1, 0].set(col0)
     result = jax.lax.fori_loop(
         1, divmin + 1, lambda k, res: _extrapolate_row(res, k, extrapolate), result
@@ -505,7 +628,7 @@ def _romberg_levels(
 
     def nloop(k, result):
         h = (b - a) / 2**k
-        s, _ = _level_sum(vfunc, a, h, 2 ** (k - 1), batch_size, f.shape, f.dtype)
+        s, _, _ = _level_sum(vfunc, a, h, 2 ** (k - 1), batch_size, f.shape, f.dtype)
         result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
         return _extrapolate_row(result, k, extrapolate)
 
@@ -553,11 +676,13 @@ def rombergts(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float
-        Absolute and relative tolerances. If I1 and I2 are two successive approximations
-        to the integral, algorithm terminates when abs(I1-I2) < max(epsabs,
-        epsrel*|I2|). Default is the square root of the machine precision of the
-        working dtype, ie of `interval`, or of the integrand's own dtype if that is the
-        coarser of the two.
+        Absolute and relative tolerances. The algorithm terminates once its estimate of
+        the error in the current approximation ``I`` falls below ``max(epsabs,
+        epsrel*|I|)``, which takes at least two refinement levels whatever the tolerance
+        and ``divmin``, since the first level's estimate has no earlier one to be judged
+        against. Default is the square root of the machine precision of the working
+        dtype, ie of `interval`, or of the integrand's own dtype if that is the coarser
+        of the two.
     divmax : int, optional
         Maximum order of extrapolation. Default is 20. Total number of function
         evaluations will be at most 2**divmax + 1
@@ -611,7 +736,10 @@ def rombergts(
     info : QuadratureInfo
         Named tuple with the following fields:
 
-        * err : (float) Estimate of the error in the approximation.
+        * err : (float) Estimate of the error in the approximation. Built from how far
+          the estimate moved over the last few refinement levels rather than over the
+          last one alone, plus the tail that movement's own contraction rate implies,
+          and floored at the precision the integrand can be summed to.
         * neval : (int) Total number of function evaluations.
         * status : (int) Flag indicating reason for termination. status of 0 means
           normal termination, any other value indicates a possible error. A human

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -44,7 +44,7 @@ def romberg(
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
-    initial_points: int = 2,
+    divmin: int = 4,
 ):
     """Romberg integration of a callable function or method.
 
@@ -71,15 +71,14 @@ def romberg(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float
-        Absolute and relative tolerances. If I1 and I2 are two
-        successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is the square root of the
-        machine precision of the working dtype, ie of `interval`, or of the integrand's
-        own dtype if that is the coarser of the two.
+        Absolute and relative tolerances. If I1 and I2 are two successive approximations
+        to the integral, algorithm terminates when abs(I1-I2) < max(epsabs,
+        epsrel*|I2|). Default is the square root of the machine precision of the working
+        dtype, ie of `interval`, or of the integrand's own dtype if that is the coarser
+        of the two.
     divmax : int, optional
-        Maximum order of extrapolation. Default is 20.
-        Total number of function evaluations will be at
-        most (initial_points - 1)*2**divmax + 1
+        Maximum order of extrapolation. Default is 20. Total number of function
+        evaluations will be at most 2**divmax + 1
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -100,20 +99,28 @@ def romberg(
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
     batch_size : int, optional
-        Maximum number of points at which to evaluate the integrand in parallel. Default
-        is one at a time. Each refinement level doubles the number of new points, so
-        raising this is usually worth a lot on GPU/TPU, at the cost of peak memory
-        scaling with it. Levels with fewer new points than one batch are padded up to a
-        full batch, so the early levels of a run cost ``batch_size`` evaluations each
-        however few points they place; that padding is what keeps a single batch shape
-        traced for every level rather than one per level. Clipped to the largest level
-        ``divmax`` allows.
-    initial_points : int > 1, optional
-        Number of points on the first refinement level, default 2. Each later level
-        doubles the number of new points, so the grids run ``initial_points``,
-        ``2*initial_points - 1``, and so on. Raising it does the early work of the
-        integration up front, which pays on GPU/TPU where the default
-        schedule spends its first levels evaluating only a handful of points each.
+        Maximum number of points at which to evaluate the integrand in parallel.
+        Defaults to ``2**divmin``, which is one batch for the whole starting grid and
+        exactly one for the refinement level after it. Each refinement level doubles the
+        number of new points, so raising this together with ``divmin`` is usually worth
+        a lot on GPU/TPU, at the cost of peak memory scaling with it. Levels with fewer
+        new points than one batch are padded up to a full batch, so a level costs
+        ``batch_size`` evaluations however few points it places; that padding is what
+        keeps a single batch shape traced for every level rather than one per level.
+        Clipped to the largest number of points any one level places.
+    divmin : int, optional
+        Number of halvings the run starts from, default 4: it begins on a grid of
+        ``2**divmin`` intervals rather than working up to one. Mirrors ``divmax``, and
+        must not exceed it.
+
+        That starting grid contains every coarser grid of the halving sequence, so the
+        coarser rows of the table are filled from the same evaluations and no
+        extrapolation is lost - the table is the one a run from ``divmin=0`` would have
+        built by the time it reached the same mesh. What is bought is that the early
+        work happens in one batch instead of a handful of levels evaluating a few points
+        each, which is where the default schedule wastes time on GPU/TPU. What is paid
+        is a floor of ``2**divmin + 1`` evaluations even on an integrand that needed
+        fewer.
 
     Returns
     -------
@@ -161,14 +168,23 @@ def romberg(
     epsrel = jnp.asarray(epsrel, dtypes.etype)
     check_size(batch_size)
     errorif(
-        not isinstance(initial_points, (int, np.integer)) or initial_points < 2,
+        not isinstance(divmin, (int, np.integer)) or divmin < 0,
         ValueError,
-        f"initial_points must be an integer >= 2, got {initial_points}",
+        f"divmin must be a non-negative integer, got {divmin}",
     )
-    m = initial_points - 1
-    # No level ever places more than `m * 2**(divmax - 1)` new points, so a larger
-    # batch would only ever be padding.
-    batch_size = min(batch_size or 1, m * 2 ** max(divmax - 1, 0))
+    errorif(
+        not isinstance(divmax, (int, np.integer)) or divmax < 0,
+        ValueError,
+        f"divmax must be a non-negative integer, got {divmax}",
+    )
+    errorif(
+        divmin > divmax,
+        ValueError,
+        f"divmin must not exceed divmax, got divmin={divmin}, divmax={divmax}",
+    )
+    # The starting sweep places `2**divmin - 1` interior points and no later level
+    # places more than `2**(divmax - 1)`, so a larger batch would only ever be padding.
+    batch_size = min(batch_size or 2**divmin, max(2**divmin, 2 ** max(divmax - 1, 0)))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -188,7 +204,7 @@ def romberg(
         dtypes.xtype,
         extrapolate,
         batch_size,
-        m,
+        divmin,
     )
 
 
@@ -206,7 +222,7 @@ def _romberg(
     xtype,
     extrapolate,
     batch_size,
-    m,
+    divmin,
 ):
     """Shared driver for ``romberg`` and ``rombergts``, differing only in ``build``."""
     # Closure conversion has to happen on the user's function, before any wrapping:
@@ -223,7 +239,7 @@ def _romberg(
             _norm=_norm,
             extrapolate=extrapolate,
             batch_size=batch_size,
-            m=m,
+            divmin=divmin,
         ),
         # Romberg has no subdivision to reuse, but it does settle on a number of
         # Richardson levels. Freezing that makes the result a fixed linear functional of
@@ -237,7 +253,7 @@ def _romberg(
             divmax=divmax,
             extrapolate=extrapolate,
             batch_size=batch_size,
-            m=m,
+            divmin=divmin,
         ),
     )
     y, state = adjoint.quadrature(ops, None, interval, args, consts, epsabs, epsrel, {})
@@ -291,6 +307,73 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
     return jax.lax.fori_loop(0, nbatch, bodyfun, jnp.zeros(shape, dtype)), nbatch
 
 
+def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
+    """Trapezoidal rule on every grid from 1 to ``2**divmin`` intervals, in one sweep.
+
+    The ``2**divmin + 1`` point grid contains every coarser grid of the halving
+    sequence: the points a level adds are those whose index has exactly as many factors
+    of two as that level is coarse. So all ``divmin + 1`` rows of column 0 come out of a
+    single pass over the finest grid, and the coarser rows cost no integrand evaluations
+    at all. That is what separates ``divmin`` from starting the refinement on a finer
+    mesh, which reaches the same finest row but leaves the table no coarser rows to
+    extrapolate from.
+
+    The rows are then built by the same halving recursion the refinement loop uses,
+    rather than by summing each grid outright, so that the table does not depend on
+    where a run started beyond the order its sums are accumulated in.
+
+    Returns the rule indexed by row, and the number of evaluations spent.
+    """
+    fa, fb = vfunc(a), vfunc(b)
+    if divmin == 0:
+        return jnp.stack([(b - a) * (fa + fb) / 2]), 2
+
+    npts = 2**divmin - 1  # interior points of the finest of these grids
+    h = (b - a) / 2**divmin
+    nbatch = (npts + batch_size - 1) // batch_size
+    offs = jnp.arange(1, batch_size + 1)
+
+    def bodyfun(k, s):
+        i = k * batch_size + offs
+        used = i <= npts
+        x = a + h * i
+        # padded lanes repeat a point this sweep genuinely evaluates; see `_level_sum`
+        x = jnp.where(used, x, x[0])
+        fx: jax.Array = vfunc(x)
+        mask = used.reshape((-1,) + (1,) * (fx.ndim - 1))
+        fx = jnp.where(mask, fx, 0)
+        # Split a level at a time rather than against a (levels, batch) membership
+        # matrix, which would multiply the peak memory of one batch by `divmin`.
+        added = []
+        for j in range(1, divmin + 1):
+            stride = 2 ** (divmin - j)
+            # the points level `j` adds: on its grid, but not on the one before it
+            new = ((i % stride) == 0) & ((i % (2 * stride)) != 0)
+            new = new.reshape((-1,) + (1,) * (fx.ndim - 1))
+            added.append(jnp.sum(jnp.where(new, fx, 0), axis=0))
+        return s + jnp.stack(added)
+
+    added = jax.lax.fori_loop(0, nbatch, bodyfun, jnp.zeros((divmin, *shape), dtype))
+
+    col0 = [(b - a) * (fa + fb) / 2]
+    for j in range(1, divmin + 1):
+        col0.append(0.5 * col0[j - 1] + ((b - a) / 2**j) * added[j - 1])
+    return jnp.stack(col0), 2 + nbatch * batch_size
+
+
+def _extrapolate_row(result, n, extrapolate):
+    """Fill row ``n``'s extrapolation columns from row ``n - 1``."""
+    if not extrapolate:
+        return result
+
+    def mloop(col, result):
+        # richardson extrapolation
+        temp = 1 / (4.0**col - 1.0) * (result[n, col - 1] - result[n - 1, col - 1])
+        return result.at[n, col].set(result[n, col - 1] + temp)
+
+    return jax.lax.fori_loop(1, n + 1, mloop, result)
+
+
 def _romberg_solve(
     rule,
     vfunc,
@@ -303,13 +386,13 @@ def _romberg_solve(
     _norm,
     extrapolate=True,
     batch_size=1,
-    m=1,
+    divmin=4,
 ):
     """Run the refinement loop, with Richardson extrapolation if it is switched on.
 
     Without it this is plain adaptive bisection of the trapezoidal rule (or of the
     tanh-sinh rule, for ``rombergts``): the same nodes and the same halving schedule,
-    reading the un-extrapolated column of the table instead of its diagonal.
+    reading column 0 of the table rather than choosing among its extrapolations.
     """
     del rule, kwargs
     a, b = interval
@@ -320,6 +403,7 @@ def _romberg_solve(
     # a batch of abscissae.
     vfunc = wrap_func(vfunc, (), interval.dtype)
     f = jax.eval_shape(vfunc, (a + b) / 2)
+    rtype = _real_dtype(f.dtype)
 
     # Which entry of row `k` is the estimate. Richardson's is the diagonal, having
     # applied `k` rounds of extrapolation to the trapezoidal values in column 0; without
@@ -327,50 +411,57 @@ def _romberg_solve(
     best = (lambda res, k: res[k, k]) if extrapolate else (lambda res, k: res[k, 0])
 
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    # The composite trapezoid rule over the m intervals of the first level: interior
-    # nodes summed in batches, endpoints evaluated directly at half weight.
-    h0 = (b - a) / m
-    s, nbatch = _level_sum(vfunc, a, h0, m - 1, batch_size, f.shape, f.dtype, step=1)
-    result = result.at[0, 0].set(h0 * (s + (vfunc(a) + vfunc(b)) / 2))
-    neval = 2 + nbatch * batch_size
+    col0, neval = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
+    result = result.at[: divmin + 1, 0].set(col0)
+
+    def advance(result, n, yprev):
+        """Extrapolate row ``n`` and measure how far its estimate moved."""
+        result = _extrapolate_row(result, n, extrapolate)
+        y = best(result, n)
+        return result, y, _norm(y - yprev)
+
+    # Rows 1 through `divmin` came out of the sweep above, so they are processed
+    # unconditionally: their evaluations are already spent, and running them is what
+    # gives the run a history before the first refinement rather than after it.
+    def initloop(k, carry):
+        result, yprev, _ = carry
+        return advance(result, k, yprev)
+
     # Explicitly typed rather than left a weak python float: this is a loop carry, and
     # has to match what `_norm` writes back into it. Real, because the error in a
     # complex valued integral is still real.
-    err = jnp.array(jnp.inf, _real_dtype(f.dtype))
-    state = (result, 1, neval, err)
+    err = jnp.array(jnp.inf, rtype)
+    result, y, err = jax.lax.fori_loop(
+        1, divmin + 1, initloop, (result, result[0, 0], err)
+    )
+    # A run given no rows to compare has no estimate at all, whatever the table says.
+    if divmin < 1:
+        err = jnp.array(jnp.inf, rtype)
+
+    state = (result, divmin + 1, neval, err, y)
 
     def ncond(state):
-        result, n, neval, err = state
-        return (n < divmax + 1) & (
-            err > jnp.maximum(epsabs, epsrel * _norm(best(result, n)))
-        )
+        result, n, neval, err, y = state
+        # `n` is the row about to be computed, so `n - 1` rows are complete and `y` is
+        # the value read off the last of them.
+        return (n < divmax + 1) & (err > jnp.maximum(epsabs, epsrel * _norm(y)))
 
     def nloop(state):
         # loop over outer number of subdivisions
-        result, n, neval, err = state
-        h = h0 / 2**n
-        s, nbatch = _level_sum(
-            vfunc, a, h, (m * 2**n) // 2, batch_size, f.shape, f.dtype
-        )
+        result, n, neval, err, yprev = state
+        h = (b - a) / 2**n
+        s, nbatch = _level_sum(vfunc, a, h, 2 ** (n - 1), batch_size, f.shape, f.dtype)
         result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
         # The padded lanes of the last batch are evaluations of the integrand like any
         # other, so they are counted here even though they do not reach the sum.
         neval += nbatch * batch_size
+        result, y, err = advance(result, n, yprev)
+        return result, n + 1, neval, err, y
 
-        def mloop(col, result):
-            # richardson extrapolation
-            temp = 1 / (4.0**col - 1.0) * (result[n, col - 1] - result[n - 1, col - 1])
-            result = result.at[n, col].set(result[n, col - 1] + temp)
-            return result
+    result, n, neval, err, y = bounded_while_loop(
+        ncond, nloop, state, max(divmax - divmin, 0) + 1
+    )
 
-        if extrapolate:
-            result = jax.lax.fori_loop(1, n + 1, mloop, result)
-        err = _norm(best(result, n) - best(result, n - 1))
-        return result, n + 1, neval, err
-
-    result, n, neval, err = bounded_while_loop(ncond, nloop, state, divmax + 1)
-
-    y = best(result, n - 1)
     status = 2 * (err > jnp.maximum(epsabs, epsrel * _norm(y)))
     state = {
         "table": result,
@@ -383,40 +474,42 @@ def _romberg_solve(
 
 
 def _romberg_levels(
-    rule, vfunc, interval, n, kwargs, *, divmax, extrapolate=True, batch_size=1, m=1
+    rule,
+    vfunc,
+    interval,
+    n,
+    kwargs,
+    *,
+    divmax,
+    extrapolate=True,
+    batch_size=1,
+    divmin=4,
 ):
     """Evaluate the table at a fixed number of levels.
 
     With ``n`` fixed this is a fixed linear combination of the integrand at fixed nodes,
     so its forward and reverse derivatives are exact transposes of one another. Mirrors
-    the loop in ``_romberg_solve`` exactly so the two agree, including which entry of
-    the table is read.
+    the schedule in ``_romberg_solve`` exactly so the two agree, including which entry
+    of the table is read.
     """
     del rule, kwargs
     a, b = interval[0], interval[-1]
     vfunc = wrap_func(vfunc, (), interval.dtype)  # see ``_romberg_solve``
     f = jax.eval_shape(vfunc, (a + b) / 2)
     result = jnp.zeros((divmax + 1, divmax + 1, *f.shape), f.dtype)
-    # The composite trapezoid rule over the m intervals of the first level, as in
-    # ``_romberg_solve``.
-    h0 = (b - a) / m
-    s, _ = _level_sum(vfunc, a, h0, m - 1, batch_size, f.shape, f.dtype, step=1)
-    result = result.at[0, 0].set(h0 * (s + (vfunc(a) + vfunc(b)) / 2))
+    col0, _ = _initial_rows(vfunc, a, b, divmin, batch_size, f.shape, f.dtype)
+    result = result.at[: divmin + 1, 0].set(col0)
+    result = jax.lax.fori_loop(
+        1, divmin + 1, lambda k, res: _extrapolate_row(res, k, extrapolate), result
+    )
 
     def nloop(k, result):
-        h = h0 / 2**k
-        s, _ = _level_sum(vfunc, a, h, (m * 2**k) // 2, batch_size, f.shape, f.dtype)
+        h = (b - a) / 2**k
+        s, _ = _level_sum(vfunc, a, h, 2 ** (k - 1), batch_size, f.shape, f.dtype)
         result = result.at[k, 0].set(0.5 * result[k - 1, 0] + h * s)
+        return _extrapolate_row(result, k, extrapolate)
 
-        def mloop(col, result):
-            temp = 1 / (4.0**col - 1.0) * (result[k, col - 1] - result[k - 1, col - 1])
-            return result.at[k, col].set(result[k, col - 1] + temp)
-
-        if not extrapolate:
-            return result
-        return jax.lax.fori_loop(1, k + 1, mloop, result)
-
-    result = jax.lax.fori_loop(1, n, nloop, result)
+    result = jax.lax.fori_loop(divmin + 1, n, nloop, result)
     return result[n - 1, n - 1] if extrapolate else result[n - 1, 0]
 
 
@@ -433,7 +526,7 @@ def rombergts(
     extrapolate: bool = True,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
-    initial_points: int = 2,
+    divmin: int = 4,
 ):
     """Romberg integration with tanh-sinh (aka double exponential) transformation.
 
@@ -460,15 +553,14 @@ def rombergts(
         If True, return the full state of the integrator. See below for more
         information.
     epsabs, epsrel : float
-        Absolute and relative tolerances. If I1 and I2 are two
-        successive approximations to the integral, algorithm terminates
-        when abs(I1-I2) < max(epsabs, epsrel*|I2|). Default is the square root of the
-        machine precision of the working dtype, ie of `interval`, or of the integrand's
-        own dtype if that is the coarser of the two.
+        Absolute and relative tolerances. If I1 and I2 are two successive approximations
+        to the integral, algorithm terminates when abs(I1-I2) < max(epsabs,
+        epsrel*|I2|). Default is the square root of the machine precision of the
+        working dtype, ie of `interval`, or of the integrand's own dtype if that is the
+        coarser of the two.
     divmax : int, optional
-        Maximum order of extrapolation. Default is 20.
-        Total number of function evaluations will be at
-        most (initial_points - 1)*2**divmax + 1
+        Maximum order of extrapolation. Default is 20. Total number of function
+        evaluations will be at most 2**divmax + 1
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -489,20 +581,28 @@ def rombergts(
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
     batch_size : int, optional
-        Maximum number of points at which to evaluate the integrand in parallel. Default
-        is one at a time. Each refinement level doubles the number of new points, so
-        raising this is usually worth a lot on GPU/TPU, at the cost of peak memory
-        scaling with it. Levels with fewer new points than one batch are padded up to a
-        full batch, so the early levels of a run cost ``batch_size`` evaluations each
-        however few points they place; that padding is what keeps a single batch shape
-        traced for every level rather than one per level. Clipped to the largest level
-        ``divmax`` allows.
-    initial_points : int > 1, optional
-        Number of points on the first refinement level, default 2. Each later level
-        doubles the number of new points, so the grids run ``initial_points``,
-        ``2*initial_points - 1``, and so on. Raising it does the early work of the
-        integration up front, which pays on GPU/TPU where the default schedule spends
-        its first levels evaluating only a handful of points each.
+        Maximum number of points at which to evaluate the integrand in parallel.
+        Defaults to ``2**divmin``, which is one batch for the whole starting grid and
+        exactly one for the refinement level after it. Each refinement level doubles the
+        number of new points, so raising this together with ``divmin`` is usually worth
+        a lot on GPU/TPU, at the cost of peak memory scaling with it. Levels with fewer
+        new points than one batch are padded up to a full batch, so a level costs
+        ``batch_size`` evaluations however few points it places; that padding is what
+        keeps a single batch shape traced for every level rather than one per level.
+        Clipped to the largest number of points any one level places.
+    divmin : int, optional
+        Number of halvings the run starts from, default 4: it begins on a grid of
+        ``2**divmin`` intervals rather than working up to one. Mirrors ``divmax``, and
+        must not exceed it.
+
+        That starting grid contains every coarser grid of the halving sequence, so the
+        coarser rows of the table are filled from the same evaluations and no
+        extrapolation is lost - the table is the one a run from ``divmin=0`` would have
+        built by the time it reached the same mesh. What is bought is that the early
+        work happens in one batch instead of a handful of levels evaluating a few points
+        each, which is where the default schedule wastes time on GPU/TPU. What is paid
+        is a floor of ``2**divmin + 1`` evaluations even on an integrand that needed
+        fewer.
 
     Returns
     -------
@@ -550,14 +650,18 @@ def rombergts(
     epsrel = jnp.asarray(epsrel, dtypes.etype)
     check_size(batch_size)
     errorif(
-        not isinstance(initial_points, (int, np.integer)) or initial_points < 2,
+        not isinstance(divmin, (int, np.integer)) or divmin < 0,
         ValueError,
-        f"initial_points must be an integer >= 2, got {initial_points}",
+        f"divmin must be a non-negative integer, got {divmin}",
     )
-    m = initial_points - 1
-    # No level ever places more than `m * 2**(divmax - 1)` new points, so a larger
-    # batch would only ever be padding.
-    batch_size = min(batch_size or 1, m * 2 ** max(divmax - 1, 0))
+    errorif(
+        divmin > divmax,
+        ValueError,
+        f"divmin must not exceed divmax, got divmin={divmin}, divmax={divmax}",
+    )
+    # The starting sweep places `2**divmin - 1` interior points and no later level
+    # places more than `2**(divmax - 1)`, so a larger batch would only ever be padding.
+    batch_size = min(batch_size or 2**divmin, max(2**divmin, 2 ** max(divmax - 1, 0)))
     if callable(norm):
         _norm: Callable[[jax.Array], jax.Array] = norm
     else:
@@ -577,5 +681,5 @@ def rombergts(
         dtypes.xtype,
         extrapolate,
         batch_size,
-        m,
+        divmin,
     )

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -285,18 +285,54 @@ def _build_tanhsinh(interval, args, consts, *, f_conv, safe=False):
     return wrap_func(fun_m, (), interval_m.dtype, safe=safe), interval_m
 
 
-def _outermost(i, f, npts):
-    """Magnitude of the first and last of the points a sweep places, as a stacked pair.
+def _outermost(x, f, opos, oval):
+    """Fold a batch of nodes into the outermost one either side that returned a value.
 
-    The two sit nearest the ends of the range, which is what the truncation estimate
-    reads. Picked out of whichever batch happens to hold them rather than evaluated
-    again; the lanes that hold neither contribute zero to the sum over batches.
+    Which node that is cannot be read off the sweep's shape, so it is carried as a
+    position alongside its magnitude. The tanh-sinh map clusters its nodes far closer to
+    an endpoint than an abscissa near that endpoint can record, so a whole stretch of
+    the outermost ones can round onto the endpoint itself, where an integrand singular
+    there returns a non-finite value that the wrapper masks away. The truncation
+    estimate wants the last node that did resolve, wherever inside the sweep it fell.
+
+    A node whose value is genuinely zero counts as not having resolved. That can only
+    move the estimate inward onto a larger term, so it costs conservatism rather than
+    correctness.
     """
-    keep = lambda which: jnp.sum(
-        jnp.where((i == which).reshape((-1,) + (1,) * (f.ndim - 1)), jnp.abs(f), 0),
+    live = jnp.any(jnp.abs(f) > 0, axis=tuple(range(1, f.ndim)))
+    far = jnp.asarray(jnp.inf, x.dtype)
+    ends = jnp.stack(
+        [jnp.min(jnp.where(live, x, far)), jnp.max(jnp.where(live, x, -far))]
+    )
+    # Padded lanes can repeat an abscissa this sweep genuinely evaluates, but they are
+    # masked to zero before they get here, so counting them again adds nothing.
+    at = lambda which: jnp.sum(
+        jnp.where((x == which).reshape((-1,) + (1,) * (f.ndim - 1)), jnp.abs(f), 0),
         axis=0,
     )
-    return jnp.stack([keep(1), keep(npts)])
+    return _keep_outermost((ends, jnp.stack([at(ends[0]), at(ends[1])])), (opos, oval))
+
+
+def _keep_outermost(new, held):
+    """Whichever of two outermost-node records reaches further out, end by end.
+
+    Reaching further out is a question about position and not about which record is
+    newer: a level places only the points interleaving those already there, so the
+    outermost of them that resolves can fall well inside the one already held.
+    """
+    (npos, nval), (opos, oval) = new, held
+    take = jnp.stack([npos[0] < opos[0], npos[1] > opos[1]])
+    return (
+        jnp.where(take, npos, opos),
+        jnp.where(take.reshape((2,) + (1,) * (oval.ndim - 1)), nval, oval),
+    )
+
+
+def _outermost_init(xtype, shape, dtype):
+    """Record for a sweep that has not resolved a node at either end yet."""
+    far = jnp.asarray(jnp.inf, xtype)
+    rzero = jnp.zeros(shape, _real_dtype(dtype))
+    return jnp.stack([far, -far]), jnp.stack([rzero, rzero])
 
 
 def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
@@ -318,8 +354,8 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
 
     ``vfunc`` takes a whole batch of abscissae; the callers wrap it to guarantee that.
 
-    Returns the sum, the sum of ``abs`` of the same values, the magnitude of the
-    outermost new node either side, and the number of batches.
+    Returns the sum, the sum of ``abs`` of the same values, the position and magnitude
+    of the outermost new node either side that resolved, and the number of batches.
     The middle two are what the error estimate's roundoff floor and its truncation term
     are built from; neither needs extra evaluations, so both are always accumulated and
     left to be eliminated as dead code on the paths that do not read them.
@@ -328,7 +364,7 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
     offs = jnp.arange(1, batch_size + 1)
 
     def bodyfun(j, carry):
-        s, sabs, ends = carry
+        s, sabs, opos, oval = carry
         i = j * batch_size + offs
         used = i <= npts
         x = a + h * (1 + step * (i - 1))
@@ -339,13 +375,16 @@ def _level_sum(vfunc, a, h, npts, batch_size, shape, dtype, *, step=2):
         return (
             s + jnp.sum(f, axis=0),
             sabs + jnp.sum(jnp.abs(f), axis=0),
-            ends + _outermost(i, f, npts),
+            *_outermost(x, f, opos, oval),
         )
 
-    rzero = jnp.zeros(shape, _real_dtype(dtype))
-    init = (jnp.zeros(shape, dtype), rzero, jnp.stack([rzero, rzero]))
-    s, sabs, ends = jax.lax.fori_loop(0, nbatch, bodyfun, init)
-    return s, sabs, ends, nbatch
+    init = (
+        jnp.zeros(shape, dtype),
+        jnp.zeros(shape, _real_dtype(dtype)),
+        *_outermost_init(jnp.asarray(a).dtype, shape, dtype),
+    )
+    s, sabs, *ends = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    return s, sabs, tuple(ends), nbatch
 
 
 def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
@@ -365,7 +404,9 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
 
     Returns the rule indexed by row, the same rule applied to ``abs`` of the integrand
     on the finest of these grids, the magnitude of the integrand at the two endpoints
-    and at the outermost interior node either side, and the number of evaluations spent.
+    and at the outermost interior node either side that resolved, and the number of
+    evaluations spent.
+
     Only the finest row of the second is needed, since the refinement loop carries it
     forward by the same halving recursion. The last two are handed back rather than
     evaluated again because the truncation estimate reads exactly those nodes; see
@@ -379,7 +420,7 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
             jnp.stack([(b - a) * (fa + fb) / 2]),
             (b - a) * fab,
             edges,
-            jnp.zeros_like(edges),
+            _outermost_init(jnp.asarray(a).dtype, shape, dtype),
             2,
         )
 
@@ -389,7 +430,7 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
     offs = jnp.arange(1, batch_size + 1)
 
     def bodyfun(k, carry):
-        s, sabs, ends = carry
+        s, sabs, opos, oval = carry
         i = k * batch_size + offs
         used = i <= npts
         x = a + h * i
@@ -411,12 +452,16 @@ def _initial_rows(vfunc, a, b, divmin, batch_size, shape, dtype):
         return (
             s + jnp.stack(added),
             sabs + jnp.sum(jnp.abs(fx), axis=0),
-            ends + _outermost(i, fx, npts),
+            *_outermost(x, fx, opos, oval),
         )
 
-    rzero = jnp.zeros(shape, _real_dtype(dtype))
-    init = (jnp.zeros((divmin, *shape), dtype), rzero, jnp.stack([rzero, rzero]))
-    added, sabs, outer = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    init = (
+        jnp.zeros((divmin, *shape), dtype),
+        jnp.zeros(shape, _real_dtype(dtype)),
+        *_outermost_init(jnp.asarray(a).dtype, shape, dtype),
+    )
+    added, sabs, *outer = jax.lax.fori_loop(0, nbatch, bodyfun, init)
+    outer = tuple(outer)
 
     col0 = [(b - a) * (fa + fb) / 2]
     for j in range(1, divmin + 1):
@@ -610,17 +655,7 @@ def _romberg_solve(
         """
         if truncation is None:
             return jnp.array(0.0, rtype)
-        return truncation(edges, outer, rtype, _norm)
-
-    def keep_outer(outer, ends):
-        """Take the newer pair of outermost nodes, for whichever end got a value.
-
-        Each level places its outermost nodes closer to the ends than the last did, so a
-        value from this level supersedes the one carried. A zero does not: it is a node
-        that has rounded onto the endpoint and been masked away, and the last node that
-        resolved remains the best that end has to say.
-        """
-        return jnp.where(ends > 0, ends, outer)
+        return truncation(edges, outer[1], rtype, _norm)
 
     def total_err(d, dprev, dprev2, resabs, outer):
         """The error in the current estimate.
@@ -701,7 +736,7 @@ def _romberg_solve(
         )
         result = result.at[n, 0].set(0.5 * result[n - 1, 0] + h * s)
         resabs = 0.5 * resabs + h * sabs
-        outer = keep_outer(outer, ends)
+        outer = _keep_outermost(ends, outer)
         # The padded lanes of the last batch are evaluations of the integrand like any
         # other, so they are counted here even though they do not reach the sum.
         neval += nbatch * batch_size

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -106,23 +106,6 @@ def _map_identity_inv(x: jax.Array, a: jax.Array, b: jax.Array):
     return x.squeeze()
 
 
-def _map_linear(t: jax.Array, a: jax.Array, b: jax.Array):
-    """Map a point t in [-1, 1] to x in [a, b]."""
-    c = (b - a) / 2
-    d = (b + a) / 2
-    x = d + c * t
-    w = c * jnp.ones_like(t)
-    return x.squeeze(), w.squeeze()
-
-
-def _map_linear_inv(x: jax.Array, a: jax.Array, b: jax.Array):
-    """Map a point x in [a, b] to t in [-1, 1]."""
-    c = (b - a) / 2
-    d = (b + a) / 2
-    t = (x - d) / c
-    return t.squeeze()
-
-
 def _map_ninfinf(t: jax.Array, a: jax.Array, b: jax.Array):
     """Map a point t in [-1, 1] to x in [-inf, inf]."""
     x = jnp.tan(t * jnp.pi / 2)
@@ -171,27 +154,21 @@ def _map_ninfb_inv(x: jax.Array, a: jax.Array, b: jax.Array):
 
 
 # A finite interval stays where it is; the three infinite cases have to be brought into
-# [-1, 1] because there is no other way to subdivide them. ``MAPFUNS_REF`` normalizes
-# the finite case too, for the one caller that needs a function on the reference
-# interval rather than one it can integrate directly: ``tanhsinh_transform`` substitutes
-# ``x = tanh(pi/2 sinh u)``, which produces points in [-1, 1] by construction.
+# [-1, 1] because there is no other way to subdivide them.
 MAPFUNS = [_map_identity, _map_ninfb, _map_ainf, _map_ninfinf]
 MAPFUNS_INV = [_map_identity_inv, _map_ninfb_inv, _map_ainf_inv, _map_ninfinf_inv]
-MAPFUNS_REF = [_map_linear, _map_ninfb, _map_ainf, _map_ninfinf]
-MAPFUNS_REF_INV = [_map_linear_inv, _map_ninfb_inv, _map_ainf_inv, _map_ninfinf_inv]
 
 # These are the branches of a `lax.switch`, so all four have to return the same dtypes,
 # and they only do so if `t`, `a` and `b` agree. Note in particular that they must not
 # be given a *weakly* typed `t`: the four differ in which of `a`/`b` they use, and a
-# weak `t` lets each branch settle on whichever of the two is present. `_map_linear`'s
-# `c * jnp.ones_like(t)` would follow a strong float32 `a`, while `_map_ninfb`'s
-# `2 / (t + 1) ** 2` would stay at the weak default, and the switch would not build.
+# weak `t` lets each branch settle on whichever of the two is present. `_map_ainf`'s
+# `a + (1 + t) / (1 - t)` would follow a strong float32 `a`, while `_map_ninfinf`'s
+# `jnp.tan(t * jnp.pi / 2)` would stay at the weak default, and the switch would not
+# build.
 # This is why the integrand is probed with `jnp.zeros((), xtype)`, not `jnp.array(0.0)`.
 
 
-def map_interval(
-    fun: Callable[..., jax.Array], interval: ArrayLike, *, reference: bool = False
-):
+def map_interval(fun: Callable[..., jax.Array], interval: ArrayLike):
     """Map a function over an arbitrary interval [a, b] to one that can be subdivided.
 
     Transform a function such that integral(fun) on interval is the same as
@@ -204,11 +181,6 @@ def map_interval(
     interval : array-like
         Lower and upper limits of integration with possible breakpoints. Use np.inf to
         denote infinite intervals.
-    reference : bool
-        Whether a finite interval should be normalized to [-1, 1] rather than left
-        alone. Only for callers that need the integrand on the reference interval
-        specifically; leaving it alone is more accurate near the endpoints. Infinite
-        intervals are mapped to [-1, 1] either way.
 
     Returns
     -------
@@ -243,15 +215,14 @@ def map_interval(
     # 3 : both infinite
     bitmask = jnp.isinf(a) + 2 * jnp.isinf(b)
 
-    fun_mapped = _MappedFunction(fun, bitmask, sgn, a, b, reference)
+    fun_mapped = _MappedFunction(fun, bitmask, sgn, a, b)
     # map original breakpoints to new domain
-    inv = MAPFUNS_REF_INV if reference else MAPFUNS_INV
     # An infinite limit gets mapped to +/-1, which the inverse maps reach only as a
     # limit: the arithmetic there is inf/inf and evaluates to nan, so needs a double
     # where type trick to avoid nan in reverse mode.
     finite = jnp.where(jnp.isinf(a), jnp.where(jnp.isinf(b), 0.0, b), a)
     interval_finite = jnp.where(jnp.isinf(interval), finite, interval)
-    interval_t: jax.Array = jax.lax.switch(bitmask, inv, interval_finite, a, b)
+    interval_t: jax.Array = jax.lax.switch(bitmask, MAPFUNS_INV, interval_finite, a, b)
     interval_t = jnp.where(interval == jnp.inf, 1, interval_t)
     interval_t = jnp.where(interval == -jnp.inf, -1, interval_t)
     return fun_mapped, interval_t
@@ -265,12 +236,10 @@ class _MappedFunction(eqx.Module):
     sgn: jax.Array
     a: jax.Array
     b: jax.Array
-    reference: bool = eqx.field(static=True, default=False)
 
     @eqx.filter_jit
     def __call__(self, t: jax.Array, *args):
-        mapfuns = MAPFUNS_REF if self.reference else MAPFUNS
-        x, w = jax.lax.switch(self.bitmask, mapfuns, t, self.a, self.b)
+        x, w = jax.lax.switch(self.bitmask, MAPFUNS, t, self.a, self.b)
         return self.sgn * w * self.fun(x, *args)
 
 
@@ -344,11 +313,163 @@ def tanhsinh_tmax(dtype, order: int | None = None) -> float:
     return tmax
 
 
+def tanhsinh_complement(t: jax.Array) -> jax.Array:
+    """Distance from the nearer end of [-1, 1] to the tanh-sinh node at ``t``.
+
+    That is ``1 - |tanh(pi/2 sinh t)|``, formed as a reciprocal rather than as a
+    subtraction so that the distance keeps its own exponent instead of being rounded
+    against the one it is measured from. Distances below an eps are the whole point of a
+    doubly exponential rule, and subtracting loses every one of them.
+    """
+    z = jnp.pi / 2 * jnp.sinh(jnp.abs(t))
+    # 1 - tanh(z) = 1/(exp(z) cosh(z)). Splitting the denominator across two factors
+    # rather than writing it as (exp(2z) + 1)/2 keeps each of them in range until the
+    # product itself leaves it, and that happens by overflowing to +inf, so the distance
+    # flushes to zero rather than to a nan.
+    return 1 / (jnp.exp(z) * jnp.cosh(z))
+
+
+def _saturated(w: jax.Array, inside: jax.Array):
+    """Drop the weight of a node whose offset from the endpoint has rounded away.
+
+    The range runs out to where the *offset* stops being representable, which is far
+    past where the position does. Beyond that the abscissa sits on the endpoint however
+    much further the offset shrinks, so its weight is one computed for a place it is not
+    and cannot stand in for the mass out there. Dropping it says so: the estimate then
+    reads the outermost node that is where it claims to be, instead of a node that has
+    stopped moving while its weight went on decaying. The mass it gives up is bounded by
+    an eps of the endpoint whatever the integrand does, since that is how far in the
+    abscissa can still resolve.
+    """
+    return jnp.where(inside, w, 0)
+
+
+def _ts_finite(t: jax.Array, c: jax.Array, a: jax.Array, b: jax.Array):
+    """Tanh-sinh node in a finite [a, b], placed as an offset from the near endpoint."""
+    alpha = (b - a) / 2
+    x = jnp.where(t > 0, b - alpha * c, a + alpha * c)
+    w = alpha * jnp.pi / 2 * jnp.cosh(t) * c * (2 - c)
+    return x.squeeze(), _saturated(w, (x > a) & (x < b)).squeeze()
+
+
+def _ts_ainf(t: jax.Array, c: jax.Array, a: jax.Array, b: jax.Array):
+    """Tanh-sinh node in [a, inf], through ``x = a + (1 + r)/(1 - r)``."""
+    del b
+    # The composed Jacobian is ``1 - r**2`` from the substitution times ``2/(1 - r)**2``
+    # from the map, which together are twice the offset. Evaluating the two factors
+    # separately would overflow at nodes whose offset is still comfortably finite, since
+    # the offset is the ratio of the two rather than either one of them.
+    #
+    # Which of the two distances goes on top is selected rather than derived, because
+    # recovering one from the other costs exactly what carrying them was meant to save:
+    # ``2 - c`` rounds to 2 for every ``c`` below an eps, and subtracting it back off
+    # returns zero instead of the distance.
+    offset = jnp.where(t > 0, 2 - c, c) / jnp.where(t > 0, c, 2 - c)
+    x = a + offset
+    w = _saturated(jnp.pi * jnp.cosh(t) * offset, x > a)
+    return x.squeeze(), w.squeeze()
+
+
+def _ts_ninfb(t: jax.Array, c: jax.Array, a: jax.Array, b: jax.Array):
+    """Tanh-sinh node in [-inf, b], through ``x = b - (1 - r)/(1 + r)``."""
+    del a
+    offset = jnp.where(t > 0, c, 2 - c) / jnp.where(t > 0, 2 - c, c)
+    x = b - offset
+    w = _saturated(jnp.pi * jnp.cosh(t) * offset, x < b)
+    return x.squeeze(), w.squeeze()
+
+
+def _ts_ninfinf(t: jax.Array, c: jax.Array, a: jax.Array, b: jax.Array):
+    """Tanh-sinh node in [-inf, inf], through ``x = tan(pi r / 2)``."""
+    del a, b
+    # Both sines are taken of the small angle rather than of one near pi/2: that puts
+    # the node at t = 0 exactly on the origin, and lets the outermost ones reach the
+    # largest representable abscissa instead of stopping where a tangent near its pole
+    # loses its argument. The ``1 - r**2`` of the substitution is split across the two
+    # so that neither the squared sine nor the secant is ever formed alone; either one
+    # leaves the range while their combination is still well inside it.
+    half = jnp.pi / 2 * c
+    x = jnp.sign(t) * jnp.sin(jnp.pi / 2 * (1 - c)) / jnp.sin(half)
+    w = (
+        jnp.pi
+        / 2
+        * jnp.cosh(t)
+        * (c / jnp.sin(half))
+        * (jnp.pi / 2 * (2 - c) / jnp.sin(half))
+    )
+    return x.squeeze(), w.squeeze()
+
+
+# The four cases of ``MAPFUNS``, each composed with the tanh-sinh substitution and
+# rewritten in terms of the node's distance from the end of [-1, 1] it clusters against.
+# Composing them rather than applying one after the other is what keeps the outermost
+# nodes: the substitution reaches far closer to an endpoint than a node written down as
+# a position can record, and the two Jacobians have factors that cancel and would
+# otherwise leave the range on their own. Being branches of a ``switch``, these carry
+# the same dtype requirement as ``MAPFUNS``.
+TS_MAPFUNS = [_ts_finite, _ts_ninfb, _ts_ainf, _ts_ninfinf]
+
+
+def tanhsinh_tmax_complement(dtype) -> float:
+    """Largest ``t`` at which a tanh-sinh node and its weight are both representable.
+
+    The counterpart of :func:`tanhsinh_tmax` for nodes carried as a distance from the
+    endpoint rather than as a position. A distance is bounded below by the smallest
+    normal instead of by one eps, most of the exponent range further out, so what
+    actually sets the cutoff is the largest weight: on an unbounded interval the weight
+    grows like the reciprocal of the distance, and so overflows before the distance
+    underflows. The bound below is the weight one, with the representability of the
+    distance as a floor under it.
+
+    Both move only logarithmically in ``t``, the clustering being doubly exponential, so
+    a margin costs almost nothing and the iteration settles in a step or two.
+
+    Warns when the precision is coarse enough that the clustering only survives against
+    an endpoint of zero. Computed in float64 on the host; the result is a compile time
+    constant.
+    """
+    eps = float(jnp.finfo(dtype).eps)
+    if eps > 1e-4:
+        warnings.warn(
+            f"tanh-sinh quadrature in {jnp.dtype(dtype).name} places its nodes as "
+            "offsets from the endpoints, so the double exponential clustering that "
+            "makes the method good at endpoint singularities survives only where the "
+            f"endpoint is zero. Anywhere else the offset is lost below {eps:.1e} of "
+            "the endpoint's own magnitude (float64 reaches 2.2e-16), leaving the rule "
+            "no better than a plain trapezoidal one there. Results are still valid; "
+            "use float32 or better, or use quadgk/quadcc instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+    tiny = float(jnp.finfo(dtype).tiny)
+    huge = float(jnp.finfo(dtype).max)
+    # Inverting c = 1/(exp(z) cosh(z)) with z = pi/2 sinh(t), ie exp(2z) = 2/c - 1.
+    reach = lambda c: float(np.arcsinh(np.log(2.0 / c - 1.0) / np.pi))
+    # The largest weight any of the maps gives a node at distance ``c`` is
+    # ``2 pi cosh(t) / c``, from the two semi-infinite ones. Solving for the ``c`` that
+    # keeps it finite needs the ``t`` it is reached at, hence the iteration; taking the
+    # running minimum is safe whether or not it has settled, since the iterates
+    # alternate around the fixed point rather than approaching it from one side. The
+    # margin leaves the outermost weight an order of magnitude short of overflowing,
+    # rather than exactly on it, for a cost in ``t`` of well under a percent.
+    limit = huge / 16
+    tmax = reach(tiny)
+    for _ in range(3):
+        tmax = min(tmax, reach(max(tiny, 2 * np.pi * np.cosh(tmax) / limit)))
+    return tmax
+
+
 def tanhsinh_transform(fun, interval):
     """Transform a function by mapping with tanh-sinh.
 
     Transform a function such that integral(fun) on interval is the same as
     integral(fun_t) on interval_t
+
+    The substitution is composed with the map onto ``interval`` rather than applied
+    after it, so that every node is built as an offset from the endpoint it clusters
+    against. Written down as a position instead, a node could get no closer to an
+    endpoint than one eps of that endpoint's own magnitude, and on an integrand singular
+    there that distance is the accuracy floor.
 
     Parameters
     ----------
@@ -369,41 +490,44 @@ def tanhsinh_transform(fun, interval):
         NotImplementedError,
         "tanh-sinh transformation with breakpoints not supported",
     )
-    xtype = jnp.asarray(interval).dtype
-    # map a, b -> [-1, 1]. The substitution below produces points in [-1, 1] whatever
-    # the original limits were, so this one caller needs the reference interval rather
-    # than the interval it was handed.
-    fun, interval = map_interval(fun, interval, reference=True)
-
-    func = _TanhSinhTransformedFunction(fun)
-
-    # we generally only need to integrate ~[-3, 3] or ~[-4, 4]
-    # we don't want to include the endpoint that maps to x==1 to avoid
-    # possible singularities, so we find the largest t s.t. x(t) < 1
-    # and use that as our interval. How large that is depends on the precision the
-    # abscissae are carried at, so it follows `interval`.
-    tmax = tanhsinh_tmax(xtype)
+    interval = jnp.asarray(interval)
+    errorif(
+        not jnp.issubdtype(interval.dtype, jnp.floating),
+        TypeError,
+        "integration limits must be real floating point, got dtype "
+        f"{interval.dtype}. Complex limits are not supported: the substitution has to "
+        "know which endpoint each node is approaching, which complex numbers do not "
+        "admit.",
+    )
+    xtype = interval.dtype
+    a, b = interval[0], interval[-1]
+    # An `xtype` scalar rather than the integer `(-1) ** (a > b)`, so that it cannot
+    # participate in promotion downstream.
+    sgn = jnp.where(a > b, -1, 1).astype(xtype)
+    a, b = jnp.minimum(a, b), jnp.maximum(a, b)
+    # bit mask to select mapping case, as in `map_interval`
+    bitmask = jnp.isinf(a) + 2 * jnp.isinf(b)
+    # The substitution lands in [-1, 1] whatever the original limits were, so how far
+    # out the range runs is a question about the arithmetic and not about `interval`.
+    tmax = tanhsinh_tmax_complement(xtype)
     interval_t = jnp.array([-tmax, tmax], dtype=xtype)
-    return func, interval_t
-
-
-# map [-1, 1] to [-inf, inf], but with mass concentrated near 0
-tanhsinh_x = lambda t: jnp.tanh(jnp.pi / 2 * jnp.sinh(t))
-tanhsinh_w = lambda t: (
-    jnp.pi / 2 * jnp.cosh(t) / jnp.cosh(jnp.pi / 2 * jnp.sinh(t)) ** 2
-)
+    return _TanhSinhTransformedFunction(fun, bitmask, sgn, a, b), interval_t
 
 
 class _TanhSinhTransformedFunction(eqx.Module):
-    """Function transformed by tanh-sinh transformation."""
+    """Function under the tanh-sinh substitution composed with the interval map."""
 
     fun: Callable[..., jax.Array]
+    bitmask: jax.Array
+    sgn: jax.Array
+    a: jax.Array
+    b: jax.Array
 
     @eqx.filter_jit
     def __call__(self, t, *args):
-        x = tanhsinh_x(t)
-        w = tanhsinh_w(t)
-        return self.fun(x, *args) * w
+        c = tanhsinh_complement(t)
+        x, w = jax.lax.switch(self.bitmask, TS_MAPFUNS, t, c, self.a, self.b)
+        return self.sgn * w * self.fun(x, *args)
 
 
 messages = {

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -732,11 +732,20 @@ QUADPACK_MODEL = ErrorModel(slack=1.0, honesty=25)
 
 # Romberg builds its estimate from the movement of the Richardson diagonal over the last
 # few levels, inflates it by the geometric tail that movement's own contraction rate
-# implies, and floors it at `50*eps*integral_abs`. As with the QUADPACK model, that
-# makes the reported value a bound rather than an estimate on a converged run; measured
-# worst case 0.5393x, on romberg at `log-squared`. Once the routine has given up the
-# bound lapses; measured worst case 14.38x, on romberg at `decay-1.01`, and given the
-# same headroom over its measurement as the QUADPACK pair, for the same reason.
+# implies, and floors it at `50*eps*integral_abs`. `rombergts` adds to that the mass its
+# map leaves outside the range being integrated over, taken from the outermost term of
+# the sum. That mass is fixed by the map rather than by the mesh, so refining converges
+# onto it and the movement between levels says nothing about it at all. Left out, it was
+# the one error either routine could have while reporting success, and it is what every
+# dishonest tanh-sinh case this table used to carry was made of.
+#
+# As with the QUADPACK model, the sum is a bound rather than an estimate on a converged
+# run; measured worst case 0.5393x, on romberg at `log-squared`. Once the routine has
+# given up the bound lapses; measured worst case 14.38x, on romberg at `decay-1.01`, and
+# given the same headroom over its measurement as the QUADPACK pair, for the same
+# reason. The tanh-sinh variant stays well inside that, its own worst being 2.71x at
+# `pow-0.99` and `decay-1.01`, the two whose endpoints come nearest to being
+# non-integrable and where the outermost term therefore has most left to account for.
 RICHARDSON_MODEL = ErrorModel(slack=1.0, honesty=35)
 
 # Tolerance for two routes to the same computation - extrapolation on against off, a
@@ -921,24 +930,25 @@ KNOWN_FAILURES = {
     ("rombergts", "beta-both-ends"): {1e-8},  # scipy too
     ("rombergts", "decay-1.01"): {1e-4},  # scipy too
     ("rombergts", "decay-1.1"): {1e-4},
-    ("rombergts", "decay-1.5"): {1e-12},
-    ("rombergts", "decay-1.5-from-0"): {1e-12},
-    ("rombergts", "decay-1.5-mirrored"): {1e-12},
+    ("rombergts", "decay-1.5"): {1e-8, 1e-12},
+    ("rombergts", "decay-1.5-from-0"): {1e-8, 1e-12},
+    ("rombergts", "decay-1.5-mirrored"): {1e-8, 1e-12},
     ("rombergts", "decay-line"): {1e-8},  # scipy too
-    ("rombergts", "exp-over-sqrt"): {1e-12},  # scipy too
+    ("rombergts", "exp-over-sqrt"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "jump"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "log-over-sqrt"): {1e-8},
+    ("rombergts", "log-squared"): {1e-12},
     ("rombergts", "loglog"): {1e-4, 1e-8},  # scipy too
     ("rombergts", "loglog-cube"): {1e-4, 1e-8},  # scipy too at 1e-8
     ("rombergts", "loglog-right"): {1e-4},  # scipy too
     ("rombergts", "loglog-sqrt"): {1e-4, 1e-8},  # scipy too
-    ("rombergts", "pow-0.5"): {1e-12},
+    ("rombergts", "pow-0.5"): {1e-8, 1e-12},
     ("rombergts", "pow-0.9"): {1e-4},
     ("rombergts", "pow-0.9-right"): {1e-4},  # scipy too
     ("rombergts", "pow-0.99"): {1e-4},  # scipy too
     ("rombergts", "sqrt-over-semicircle"): {1e-12},  # scipy too
     ("rombergts", "sqrt-tan"): {1e-8, 1e-12},  # scipy too
-    ("rombergts", "vector-mixed"): {1e-12},
+    ("rombergts", "vector-mixed"): {1e-8, 1e-12},
     ("romberg", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("romberg", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
 }
@@ -978,28 +988,7 @@ KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("quadts", "sqrt-over-semicircle"): {1e-4, 1e-8},
     ("quadts", "sqrt-tan"): {1e-4, 1e-8},
     ("quadts", "vector-mixed"): {1e-4, 1e-8},
-    ("rombergts", "beta-both-ends"): {1e-4, 1e-8, 1e-12},  # scipy too at 1e-8, 1e-12
-    ("rombergts", "decay-1.01"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "decay-1.1"): {1e-4, 1e-8, 1e-12},
-    ("rombergts", "decay-1.5"): {1e-8, 1e-12},
-    ("rombergts", "decay-1.5-from-0"): {1e-8, 1e-12},
-    ("rombergts", "decay-1.5-mirrored"): {1e-8, 1e-12},
-    ("rombergts", "decay-line"): {1e-8, 1e-12},  # scipy too
-    ("rombergts", "exp-over-sqrt"): {1e-8, 1e-12},  # scipy too at 1e-12
     ("rombergts", "jump"): {1e-4},  # scipy too
-    ("rombergts", "log-over-sqrt"): {1e-8, 1e-12},
-    ("rombergts", "log-squared"): {1e-12},
-    ("rombergts", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "loglog-cube"): {1e-4, 1e-8, 1e-12},  # scipy too at 1e-8, 1e-12
-    ("rombergts", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "loglog-sqrt"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "pow-0.5"): {1e-8, 1e-12},
-    ("rombergts", "pow-0.9"): {1e-4, 1e-8, 1e-12},
-    ("rombergts", "pow-0.9-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "pow-0.99"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "sqrt-over-semicircle"): {1e-8, 1e-12},  # scipy too at 1e-12
-    ("rombergts", "sqrt-tan"): {1e-8, 1e-12},  # scipy too at 1e-12
-    ("rombergts", "vector-mixed"): {1e-8, 1e-12},
 }
 
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -938,7 +938,7 @@ KNOWN_FAILURES = {
     ("rombergts", "pow-0.9-right"): {1e-4},  # scipy too
     ("rombergts", "pow-0.99"): {1e-4},  # scipy too
     ("rombergts", "sqrt-over-semicircle"): {1e-12},  # scipy too
-    ("rombergts", "sqrt-tan"): {1e-12},  # scipy too
+    ("rombergts", "sqrt-tan"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "vector-mixed"): {1e-12},
     ("romberg", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("romberg", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
@@ -991,6 +991,7 @@ KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("rombergts", "decay-line"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "exp-over-sqrt"): {1e-8, 1e-12},  # scipy too at 1e-12
     ("rombergts", "jump"): {1e-4, 1e-8, 1e-12},  # scipy too
+    ("rombergts", "log-cos"): {1e-12},
     ("rombergts", "log-decay"): {1e-12},
     ("rombergts", "log-over-sqrt"): {1e-8, 1e-12},
     ("rombergts", "log-squared"): {1e-12},

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -730,14 +730,14 @@ class ErrorModel(NamedTuple):
 # it however far under the bound it currently measures.
 QUADPACK_MODEL = ErrorModel(slack=1.0, honesty=25)
 
-# Romberg reports the difference between successive Richardson diagonals. That is an
-# indicator of convergence rather than a bound, and carries no safety margin of any
-# kind, so it can come in under the true error even on a converged run - measured worst
-# case 1.500x, on rombergts at `sqrt-cubed`, which is the slack figure exactly rather
-# than merely close to it. On a failed run it degrades much further than the QUADPACK
-# estimate does, to a measured 144x. Set at the same fraction above their measurements
-# as the QUADPACK pair, for the same reason.
-RICHARDSON_MODEL = ErrorModel(slack=2.0, honesty=175)
+# Romberg builds its estimate from the movement of the Richardson diagonal over the last
+# few levels, inflates it by the geometric tail that movement's own contraction rate
+# implies, and floors it at `50*eps*integral_abs`. As with the QUADPACK model, that
+# makes the reported value a bound rather than an estimate on a converged run; measured
+# worst case 0.5393x, on romberg at `log-squared`. Once the routine has given up the
+# bound lapses; measured worst case 14.38x, on romberg at `decay-1.01`, and given the
+# same headroom over its measurement as the QUADPACK pair, for the same reason.
+RICHARDSON_MODEL = ErrorModel(slack=1.0, honesty=35)
 
 # Tolerance for two routes to the same computation - extrapolation on against off, a
 # different adjoint, jit against eager - which should agree to ~1 ULP. Tight enough
@@ -926,13 +926,12 @@ KNOWN_FAILURES = {
     ("rombergts", "decay-1.5-mirrored"): {1e-12},
     ("rombergts", "decay-line"): {1e-8},  # scipy too
     ("rombergts", "exp-over-sqrt"): {1e-12},  # scipy too
-    ("rombergts", "jump"): {1e-4, 1e-8, 1e-12},  # scipy too
+    ("rombergts", "jump"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "log-over-sqrt"): {1e-8},
     ("rombergts", "loglog"): {1e-4, 1e-8},  # scipy too
     ("rombergts", "loglog-cube"): {1e-4, 1e-8},  # scipy too at 1e-8
     ("rombergts", "loglog-right"): {1e-4},  # scipy too
     ("rombergts", "loglog-sqrt"): {1e-4, 1e-8},  # scipy too
-    ("rombergts", "narrow-gauss"): {1e-4, 1e-8, 1e-12},
     ("rombergts", "pow-0.5"): {1e-12},
     ("rombergts", "pow-0.9"): {1e-4},
     ("rombergts", "pow-0.9-right"): {1e-4},  # scipy too
@@ -942,9 +941,6 @@ KNOWN_FAILURES = {
     ("rombergts", "vector-mixed"): {1e-12},
     ("romberg", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("romberg", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("romberg", "osc-exp-decay"): {1e-4},
-    ("romberg", "osc-tail"): {1e-4},  # scipy too
-    ("romberg", "sin-inverse"): {1e-4},  # scipy too
 }
 
 # Cases where the reported error understates the true error, which is a defect rather
@@ -990,17 +986,13 @@ KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("rombergts", "decay-1.5-mirrored"): {1e-8, 1e-12},
     ("rombergts", "decay-line"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "exp-over-sqrt"): {1e-8, 1e-12},  # scipy too at 1e-12
-    ("rombergts", "jump"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "log-cos"): {1e-12},
-    ("rombergts", "log-decay"): {1e-12},
+    ("rombergts", "jump"): {1e-4},  # scipy too
     ("rombergts", "log-over-sqrt"): {1e-8, 1e-12},
     ("rombergts", "log-squared"): {1e-12},
     ("rombergts", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("rombergts", "loglog-cube"): {1e-4, 1e-8, 1e-12},  # scipy too at 1e-8, 1e-12
     ("rombergts", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("rombergts", "loglog-sqrt"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("rombergts", "lorentzian-halfline"): {1e-4},
-    ("rombergts", "narrow-gauss"): {1e-4, 1e-8, 1e-12},
     ("rombergts", "pow-0.5"): {1e-8, 1e-12},
     ("rombergts", "pow-0.9"): {1e-4, 1e-8, 1e-12},
     ("rombergts", "pow-0.9-right"): {1e-4, 1e-8, 1e-12},  # scipy too
@@ -1008,11 +1000,6 @@ KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("rombergts", "sqrt-over-semicircle"): {1e-8, 1e-12},  # scipy too at 1e-12
     ("rombergts", "sqrt-tan"): {1e-8, 1e-12},  # scipy too at 1e-12
     ("rombergts", "vector-mixed"): {1e-8, 1e-12},
-    ("romberg", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("romberg", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("romberg", "osc-exp-decay"): {1e-4},
-    ("romberg", "osc-tail"): {1e-4},  # scipy too
-    ("romberg", "sin-inverse"): {1e-4},  # scipy too
 }
 
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -706,14 +706,14 @@ class ErrorModel(NamedTuple):
 # `50*eps*integral_abs`, which makes the reported value a bound rather than an estimate:
 # on a converged run it is never optimistic, measured worst case 0.9999x, on quadcc at
 # `vector-mixed`. Once the routine has given up that guarantee lapses, but the result
-# must still be in the right league; measured worst case 10.5x, on quadgk at
-# `loglog-right`, over the cases the suite enforces rather than those in
+# must still be in the right league; measured worst case 15.9x, on quadts at
+# `interior-marked`, over the cases the suite enforces rather than those in
 # `KNOWN_DISHONEST`. The slack figure sits so close to its measurement that
 # `vector-mixed` is effectively the case defining it: the two components share one mesh
 # and one estimate, which stretches the bound to its limit, and a change that loosened
 # the estimator at all would fail there first.
 #
-# The honesty figure is not held that tight, and is deliberately left at more than twice
+# The honesty figure is not held that tight, and is deliberately left half again above
 # its worst measurement. What it bounds is the estimate on runs that reported failure,
 # where there is no bound to appeal to and the number is a heuristic layered on a
 # heuristic; pinning it to the measurement would turn ordinary variation between
@@ -874,13 +874,11 @@ def solve_once(method, i, tol, *, interval_as_array=False, **kwargs):
 # `scipy.integrate.quad` misses 1e-4 on both members of the pair with its default
 # `limit`, and only clears it given ten times as many sub-intervals.
 #
-# The third is the Romberg pair reporting success on an answer it never sampled: the
-# level 0 and level 1 estimates can agree by accident - because the integrand is NaN at
-# an endpoint, or because a narrow feature falls between the three points those levels
-# use - and nothing requires a minimum depth before that agreement is believed. These
-# are the most serious entries in the table, being wrong answers returned with a status
-# of 0 rather than shortfalls in accuracy, and they appear in `KNOWN_DISHONEST` as well
-# for that reason.
+# The third is marked `# unaccelerated`, and is the price of running `quadts` without
+# the convergence acceleration; see `accelerates` in `tests/test_adaptive.py` for why it
+# is run that way. They would come back if the mass the tanh-sinh map leaves outside its
+# range were carried through to the extrapolated estimate, which would let the
+# acceleration stay on without costing the error bound.
 #
 # `# scipy too` marks the entries where the nearest scipy routine does not deliver the
 # tolerance either, measured against scipy 1.17.1: `scipy.integrate.tanhsinh` for
@@ -891,8 +889,8 @@ def solve_once(method, i, tol, *, interval_as_array=False, **kwargs):
 # allowed the same number of sub-intervals as the default `max_ninter` the quadax runs
 # use. Where the note names tolerances, scipy fails at those and delivers at the others.
 #
-# 35 of the 40 convergence entries carry the note at one tolerance or more, and 8 of
-# the 21 dishonesty entries. That is the useful part of the annotation. An unmarked
+# 35 of the 44 convergence entries carry the note at one tolerance or more, and 2 of
+# the 5 dishonesty entries. That is the useful part of the annotation. An unmarked
 # entry is one where a widely used routine does solve the problem, so the shortfall is
 # quadax's; a marked one says the integrand is hard for the method rather than badly
 # implemented here, and `scipy.integrate.tanhsinh` failing on much the same set as
@@ -918,15 +916,19 @@ KNOWN_FAILURES = {
     ("quadts", "beta-both-ends"): {1e-8},  # scipy too
     ("quadts", "decay-1.01"): {1e-4, 1e-8},  # scipy too
     ("quadts", "decay-1.1"): {1e-4, 1e-8},
-    ("quadts", "log-over-sqrt"): {1e-8},
+    ("quadts", "interior-marked"): {1e-8},  # unaccelerated
+    ("quadts", "interior-unmarked"): {1e-8},  # unaccelerated
     ("quadts", "loglog"): {1e-4, 1e-8},  # scipy too
-    ("quadts", "loglog-cube"): {1e-8},  # scipy too
+    ("quadts", "loglog-cube"): {1e-4, 1e-8},  # 1e-4 unaccelerated, scipy too
     ("quadts", "loglog-right"): {1e-4, 1e-8},  # scipy too
     ("quadts", "loglog-sqrt"): {1e-4, 1e-8},  # scipy too
     ("quadts", "osc-tail"): {1e-4, 1e-8},  # scipy too
+    ("quadts", "pow-0.9"): {1e-4, 1e-8},  # unaccelerated
     ("quadts", "pow-0.9-right"): {1e-4, 1e-8},  # scipy too
     ("quadts", "pow-0.99"): {1e-4, 1e-8},  # scipy too
     ("quadts", "sin-inverse"): {1e-4, 1e-8},  # scipy too
+    ("quadts", "sqrt-over-semicircle"): {1e-8},  # unaccelerated
+    ("quadts", "two-interior"): {1e-8},  # unaccelerated
     ("rombergts", "beta-both-ends"): {1e-8},  # scipy too
     ("rombergts", "decay-1.01"): {1e-4},  # scipy too
     ("rombergts", "jump"): {1e-8, 1e-12},  # scipy too
@@ -955,28 +957,16 @@ KNOWN_FAILURES = {
 # `# host dependent` marks the entries that only reach the dishonest branch on some
 # machines. Where the acceleration cannot fit a problem's asymptotics the reported error
 # is ULP-chaotic.
+#
+# The one `quadts` entry left is dishonest by 1.07x, the estimate of the mass its map
+# leaves outside the range it integrates over being sharp enough to leave nothing over
+# for the rest of the error.
 KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("quadcc", "loglog-cube"): {1e-4},  # scipy too
     ("quadcc", "sqrt-tan"): {1e-12},
     ("quadgk", "loglog"): {1e-4},  # host dependent
     ("quadgk", "loglog-cube"): {1e-4},  # scipy too
-    ("quadts", "beta-both-ends"): {1e-4, 1e-8, 1e-12},  # scipy too at 1e-8, 1e-12
-    ("quadts", "decay-1.01"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("quadts", "decay-1.1"): {1e-4, 1e-8, 1e-12},
-    ("quadts", "decay-1.5"): {1e-4, 1e-8},
-    ("quadts", "decay-1.5-from-0"): {1e-4, 1e-8},
-    ("quadts", "decay-1.5-mirrored"): {1e-4, 1e-8},
-    ("quadts", "decay-line"): {1e-4, 1e-8},  # scipy too at 1e-8
-    ("quadts", "exp-over-sqrt"): {1e-8},
-    ("quadts", "interior-marked"): {1e-4, 1e-8},  # scipy too
-    ("quadts", "log-over-sqrt"): {1e-4, 1e-8},
-    ("quadts", "loglog"): {1e-4},  # host dependent
-    ("quadts", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("quadts", "pow-0.5"): {1e-4, 1e-8},
-    ("quadts", "pow-0.9-right"): {1e-4, 1e-8, 1e-12},  # scipy too
-    ("quadts", "sqrt-over-semicircle"): {1e-4, 1e-8},
-    ("quadts", "sqrt-tan"): {1e-4, 1e-8},
-    ("quadts", "vector-mixed"): {1e-4, 1e-8},
+    ("quadts", "decay-line"): {1e-8},  # 1.07x, the tail estimate has no margin
 }
 
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -891,8 +891,8 @@ def solve_once(method, i, tol, *, interval_as_array=False, **kwargs):
 # allowed the same number of sub-intervals as the default `max_ninter` the quadax runs
 # use. Where the note names tolerances, scipy fails at those and delivers at the others.
 #
-# 39 of the 54 convergence entries carry the note at one tolerance or more, and 25 of
-# the 49 dishonesty entries. That is the useful part of the annotation. An unmarked
+# 35 of the 40 convergence entries carry the note at one tolerance or more, and 8 of
+# the 21 dishonesty entries. That is the useful part of the annotation. An unmarked
 # entry is one where a widely used routine does solve the problem, so the shortfall is
 # quadax's; a marked one says the integrand is hard for the method rather than badly
 # implemented here, and `scipy.integrate.tanhsinh` failing on much the same set as
@@ -929,26 +929,15 @@ KNOWN_FAILURES = {
     ("quadts", "sin-inverse"): {1e-4, 1e-8},  # scipy too
     ("rombergts", "beta-both-ends"): {1e-8},  # scipy too
     ("rombergts", "decay-1.01"): {1e-4},  # scipy too
-    ("rombergts", "decay-1.1"): {1e-4},
-    ("rombergts", "decay-1.5"): {1e-8, 1e-12},
-    ("rombergts", "decay-1.5-from-0"): {1e-8, 1e-12},
-    ("rombergts", "decay-1.5-mirrored"): {1e-8, 1e-12},
-    ("rombergts", "decay-line"): {1e-8},  # scipy too
-    ("rombergts", "exp-over-sqrt"): {1e-8, 1e-12},  # scipy too
     ("rombergts", "jump"): {1e-8, 1e-12},  # scipy too
-    ("rombergts", "log-over-sqrt"): {1e-8},
-    ("rombergts", "log-squared"): {1e-12},
     ("rombergts", "loglog"): {1e-4, 1e-8},  # scipy too
-    ("rombergts", "loglog-cube"): {1e-4, 1e-8},  # scipy too at 1e-8
+    ("rombergts", "loglog-cube"): {1e-8},  # scipy too
     ("rombergts", "loglog-right"): {1e-4},  # scipy too
     ("rombergts", "loglog-sqrt"): {1e-4, 1e-8},  # scipy too
-    ("rombergts", "pow-0.5"): {1e-8, 1e-12},
-    ("rombergts", "pow-0.9"): {1e-4},
     ("rombergts", "pow-0.9-right"): {1e-4},  # scipy too
     ("rombergts", "pow-0.99"): {1e-4},  # scipy too
     ("rombergts", "sqrt-over-semicircle"): {1e-12},  # scipy too
     ("rombergts", "sqrt-tan"): {1e-8, 1e-12},  # scipy too
-    ("rombergts", "vector-mixed"): {1e-8, 1e-12},
     ("romberg", "loglog"): {1e-4, 1e-8, 1e-12},  # scipy too
     ("romberg", "loglog-right"): {1e-4, 1e-8, 1e-12},  # scipy too
 }
@@ -988,7 +977,6 @@ KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("quadts", "sqrt-over-semicircle"): {1e-4, 1e-8},
     ("quadts", "sqrt-tan"): {1e-4, 1e-8},
     ("quadts", "vector-mixed"): {1e-4, 1e-8},
-    ("rombergts", "jump"): {1e-4},  # scipy too
 }
 
 

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -48,19 +48,70 @@ from .problems import (
 config.update("jax_enable_x64", True)
 
 
-# Extrapolation is what makes the hard problems solvable, so it is switched on for the
-# whole suite. The unaccelerated path is swept over the smooth problems only, where
-# the subdivision converges on its own and there is a right answer to hold it to; on
-# the rest it can only fail, which the acceleration tests below pin down directly.
-CASES = [(i, True) for i in ALL] + [(i, False) for i in SMOOTH]
+METHODS = [(quadgk, "gk"), (quadcc, "cc"), (quadts, "ts")]
 
 
-# A list rather than a callable: pytest passes an id function each argument of the pair
-# separately, so it cannot name the two together.
-CASE_IDS = [
-    f"{problem_id(i)}-{'extrap' if extrapolate else 'plain'}"
-    for i, extrapolate in CASES
-]
+def accelerates(method):
+    """Whether the convergence acceleration is used with ``method`` at all.
+
+    Not with ``quadts``, which is also the one routine it is off by default in. The
+    epsilon algorithm accelerates the sequence of mesh sums, and every one of those
+    sums omits the mass the tanh-sinh map leaves outside the range it integrates over.
+    Whether the acceleration can do anything with that depends on the endpoint.
+
+    Where the singular endpoint is zero, bisecting towards it narrows the omitted
+    sliver as well, and the bias falls geometrically - a clean factor per level, since
+    the omitted mass is a fixed power of the sub-interval width. That is exactly the
+    kind of sequence the table sums, so the extrapolated value is far better than the
+    mesh sum and its estimate covers it. Where the endpoint has no floating point range
+    beneath it, an infinite interval's mapped end or a breakpoint away from the origin,
+    the outermost node rounds onto the endpoint however narrow the sub-interval gets,
+    the omitted mass stops falling, and the bias becomes a constant offset that the
+    table can neither remove nor see. Its estimate is preferred wherever it is the
+    smaller of the two, so what gets reported is then not a bound, by up to three
+    orders of magnitude on the slowly decaying tails.
+
+    The sweep cannot choose per problem, so the acceleration is off for the whole of
+    ``quadts``. What that costs is the endpoint-at-zero problems, tabulated in
+    ``KNOWN_FAILURES`` as ``# unaccelerated``; carrying the omitted mass through to the
+    extrapolated estimate would let it stay on and cost neither.
+    """
+    return method is not quadts
+
+
+def _sweep():
+    """The ``(routine, problem, extrapolate)`` cases, each with a readable id.
+
+    Extrapolation is what makes the hard problems solvable, so the routines that use it
+    take the sweep over every problem with it on, and their unaccelerated path is swept
+    over the smooth problems only, where the subdivision converges on its own and there
+    is a right answer to hold it to. On the rest it can only fail, which the
+    acceleration tests below pin down directly. A routine that never accelerates takes
+    the one sweep over every problem and has no second one to run.
+    """
+    for method, name in METHODS:
+        on = accelerates(method)
+        tag = "extrap" if on else "plain"
+        for i in ALL:
+            yield (method, i, on), f"{problem_id(i)}-{tag}-{name}"
+        if on:
+            for i in SMOOTH:
+                yield (method, i, False), f"{problem_id(i)}-plain-{name}"
+
+
+# Lists rather than callables: pytest passes an id function each argument of a tuple
+# separately, so it cannot name them together.
+CASES, CASE_IDS = (list(t) for t in zip(*_sweep()))
+
+
+def is_main_sweep(method, extrapolate):
+    """Whether this case is the routine's sweep over every problem.
+
+    The tables of expected failures describe that sweep, and only it is required to
+    converge. The smooth-only sweep with the acceleration off exists to show that the
+    un-accelerated path does not regress, so it is held to neither.
+    """
+    return extrapolate or not accelerates(method)
 
 
 # The tightest tolerance is where the subdivision runs deepest and most of the sweep's
@@ -72,9 +123,8 @@ TOL_PARAMS = [
 ]
 
 
-@pytest.mark.parametrize("method", [quadgk, quadcc, quadts], ids=["gk", "cc", "ts"])
 @pytest.mark.parametrize("tol", TOL_PARAMS)
-@pytest.mark.parametrize("i, extrapolate", CASES, ids=CASE_IDS)
+@pytest.mark.parametrize("method, i, extrapolate", CASES, ids=CASE_IDS)
 class TestAdaptive:
     """Every example problem, through every adaptive routine, at every tolerance.
 
@@ -98,7 +148,7 @@ class TestAdaptive:
         solve, since reporting failure is not an excuse for misreporting by how much.
         """
         prob = PROBLEMS[i]
-        if extrapolate:
+        if is_main_sweep(method, extrapolate):
             xfail_if_dishonest(request, method, prob, tol)
         y, info = solve_once(method, i, tol, extrapolate=extrapolate)
         assert_honest(y, info, prob, tol)
@@ -106,14 +156,14 @@ class TestAdaptive:
     def test_converges(self, request, method, tol, i, extrapolate):
         """The routine reaches the tolerance it was asked for and reports success."""
         prob = PROBLEMS[i]
-        if extrapolate:
+        main = is_main_sweep(method, extrapolate)
+        if main:
             xfail_if_known(request, method, prob, tol)
         y, info = solve_once(method, i, tol, extrapolate=extrapolate)
         # The tightest tolerance sits below the roundoff floor of the near-divergent
         # problems, where declining to converge is the right answer rather than a
-        # failure, and the un-accelerated path is only swept to show it does not
-        # regress.
-        if not (extrapolate and tol in CONVERGENT_TOLS) and int(info.status) != 0:
+        # failure, and the smooth-only sweep is there to show it does not regress.
+        if not (main and tol in CONVERGENT_TOLS) and int(info.status) != 0:
             pytest.skip("convergence is not required of this case")
         assert_converged(y, info, prob, tol)
 
@@ -158,7 +208,7 @@ class TestRuleOrders:
                 epsabs=self.TOL,
                 epsrel=self.TOL,
                 order=order,
-                extrapolate=True,
+                extrapolate=accelerates(method),
             )
             assert int(info.status) == 0, (
                 f"{prob['name']} at order {order}: {quadax.STATUS[int(info.status)]}"

--- a/tests/test_fixed_order.py
+++ b/tests/test_fixed_order.py
@@ -393,7 +393,8 @@ class TestErrorEstimates:
         estimate that reduced over the components too early, rather than being formed
         component by component and normed once at the end, would come out below this.
         """
-        funs = [_exp_fun, lambda x: 1 / (1 + 25 * x**2), jnp.sqrt]
+        step = lambda x: jnp.where(x < 0.3, 0.0, 1.0)
+        funs = [_exp_fun, jnp.sqrt, step]
         together = lambda x: jnp.stack([f(x) for f in funs], axis=-1)
         r = rule(order)
         combined = float(r.integrate(together, 0.0, 1.0, ())[1])

--- a/tests/test_fixed_order.py
+++ b/tests/test_fixed_order.py
@@ -235,6 +235,266 @@ class TestTanhSinhConvergence:
         assert errors[-1] < ROUNDOFF_FLOOR
 
 
+# ---------------------------------------------------------------------------
+# Error estimates
+# ---------------------------------------------------------------------------
+# Every rule returns an error estimate alongside its value, and the whole of the
+# adaptive layer above rests on that number: it decides which sub-interval to split,
+# when to stop, and what the caller is finally told the answer is worth. The contract
+# it has to keep is one-sided. An estimate that is too large only costs work, while one
+# that is too small is a wrong answer reported as a right one, because a caller has
+# nothing else to go on. So these tests ask for a bound and not for a ratio, and a rule
+# that cannot deliver one on some integrand is listed in `RULE_KNOWN_DISHONEST`.
+
+
+def _sine_fun(x):
+    return jnp.sin(5 * x)
+
+
+def _sine_exact(a, b):
+    return (np.cos(5 * a) - np.cos(5 * b)) / 5
+
+
+# ``(fun, exact, interval)``, roughly in order of how hard the integrand makes the
+# estimate's job: analytic, then peaked, then non-smooth at an interior point, then
+# singular at an endpoint, which is where an estimate is under the most pressure and
+# where the three rules stop agreeing about how well they are doing.
+ERROR_CASES = {
+    "exp": (_exp_fun, _exp_exact, (-1.0, 1.0)),
+    "exp-shifted": (_exp_fun, _exp_exact, (1.7, 3.9)),
+    "gaussian": (_gaussian_fun, _gaussian_exact, (-1.0, 2.0)),
+    "rational": (_rational_fun, _rational_exact, (-1.0, 1.0)),
+    "cubic": (
+        lambda x: x**3 - 2 * x + 1,
+        lambda a, b: (b**4 - a**4) / 4 - (b**2 - a**2) + (b - a),
+        (-1.0, 2.0),
+    ),
+    "sine": (_sine_fun, _sine_exact, (0.0, 1.0)),
+    "runge": (
+        lambda x: 1 / (1 + 25 * x**2),
+        lambda a, b: (np.arctan(5 * b) - np.arctan(5 * a)) / 5,
+        (-1.0, 1.0),
+    ),
+    "kink": (
+        lambda x: jnp.abs(x - 0.3),
+        lambda a, b: (
+            ((b - 0.3) ** 2 * np.sign(b - 0.3) + (0.3 - a) ** 2 * np.sign(0.3 - a)) / 2
+        ),
+        (0.0, 1.0),
+    ),
+    "sqrt": (jnp.sqrt, lambda a, b: 2 / 3 * (b**1.5 - a**1.5), (0.0, 1.0)),
+    "recip-sqrt": (
+        lambda x: x**-0.5,
+        lambda a, b: 2 * (b**0.5 - a**0.5),
+        (0.0, 1.0),
+    ),
+    "log": (
+        jnp.log,
+        lambda a, b: scipy.special.xlogy(b, b) - b - (scipy.special.xlogy(a, a) - a),
+        (0.0, 1.0),
+    ),
+    "pow-0.9": (lambda x: x**-0.9, lambda a, b: 10 * (b**0.1 - a**0.1), (0.0, 1.0)),
+    "complex-osc": (
+        lambda x: jnp.exp(5j * x),
+        lambda a, b: (np.exp(5j * b) - np.exp(5j * a)) / 5j,
+        (0.0, 1.0),
+    ),
+}
+
+# Three widely separated orders per rule rather than every order it offers: the estimate
+# is built the same way at each, and what changes across an order sweep is how much of
+# the integrand the nodes resolve, which the extremes already bracket.
+RULE_ORDERS = {
+    "gk": (GaussKronrodRule, [15, 31, 61]),
+    "cc": (ClenshawCurtisRule, [8, 32, 128]),
+    "ts": (TanhSinhRule, [21, 61, 101]),
+}
+RULE_ORDER_PARAMS = [
+    (cls, order) for cls, orders in RULE_ORDERS.values() for order in orders
+]
+RULE_ORDER_IDS = [
+    f"{name}-{order}" for name, (_, orders) in RULE_ORDERS.items() for order in orders
+]
+
+# ``(rule, case) -> {orders}`` where the reported error comes out below the true one.
+# Kept as a table rather than folded into a tolerance so that the exceptions stay
+# countable, and so that one which starts passing shows up as an XPASS instead of
+# disappearing into the slack. The single entry is the endpoint singularity caveat in
+# `ClenshawCurtisRule`'s own documentation: its nodes cluster at the endpoints, so the
+# two rules of the nested pair agree closely there while neither has resolved anything,
+# and the difference between them understates what is left. It clears as the order
+# rises, being 2.3x at order 8 and honest from order 32 on.
+RULE_KNOWN_DISHONEST: dict[tuple[str, str], set[int]] = {
+    ("cc", "pow-0.9"): {8},
+}
+
+
+def _rule_name(rule):
+    """The short key a rule appears under in `RULE_ORDERS`."""
+    return next(k for k, (cls, _) in RULE_ORDERS.items() if cls is rule)
+
+
+def xfail_if_rule_dishonest(request, rule, order, case):
+    """Mark the running test xfail if `RULE_KNOWN_DISHONEST` lists this case."""
+    orders = RULE_KNOWN_DISHONEST.get((_rule_name(rule), case))
+    if orders is not None and order in orders:
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    f"{rule.__name__} order {order} understates its error on {case}"
+                ),
+                strict=False,
+            )
+        )
+
+
+# Checked in single as well as double precision. The estimate is assembled from
+# quantities of the working dtype and compared against thresholds derived from its eps,
+# so a term that is right only at float64 would show up here rather than in the dtype
+# plumbing tests below.
+ERROR_DTYPES = ["float64", "float32"]
+
+
+@pytest.mark.parametrize("rule, order", RULE_ORDER_PARAMS, ids=RULE_ORDER_IDS)
+class TestErrorEstimates:
+    """What ``integrate`` reports as ``err`` has to bound the error it actually made."""
+
+    @pytest.mark.parametrize("case", ERROR_CASES, ids=str)
+    @pytest.mark.parametrize("dtype", ERROR_DTYPES)
+    def test_error_estimate_is_honest(self, request, rule, order, case, dtype):
+        """The reported error is at least the true one, with no margin allowed."""
+        xfail_if_rule_dishonest(request, rule, order, case)
+        fun, exact, (a, b) = ERROR_CASES[case]
+        y, err, _, _ = rule(order).integrate(
+            fun, jnp.array(a, dtype), jnp.array(b, dtype), ()
+        )
+        true_err = abs(complex(y) - complex(exact(a, b)))
+        assert true_err <= float(err), (
+            f"{case} at {dtype}: reported {float(err):.3e} < true {true_err:.3e}"
+        )
+
+    def test_a_zero_integrand_reports_no_error(self, rule, order):
+        """An integrand that vanishes everywhere is integrated exactly.
+
+        Worth pinning because the estimate is a chain of ratios and logarithms of
+        sampled quantities, every one of which is degenerate here, and any of them
+        resolving to a nan rather than being substituted away would surface as an
+        error estimate on an integral that is exactly right.
+        """
+        _, err, y_abs, y_mmn = rule(order).integrate(lambda x: 0.0 * x, 0.0, 1.0, ())
+        for v in (err, y_abs, y_mmn):
+            np.testing.assert_array_equal(np.asarray(v), 0.0)
+
+    def test_a_vector_integrand_is_charged_its_worst_component(self, rule, order):
+        """``err`` for a vector integrand is the norm over the component errors.
+
+        The default norm is the max, so integrating three integrands together has to
+        report exactly what the worst of them reports on its own. Any part of the
+        estimate that reduced over the components too early, rather than being formed
+        component by component and normed once at the end, would come out below this.
+        """
+        funs = [_exp_fun, lambda x: 1 / (1 + 25 * x**2), jnp.sqrt]
+        together = lambda x: jnp.stack([f(x) for f in funs], axis=-1)
+        r = rule(order)
+        combined = float(r.integrate(together, 0.0, 1.0, ())[1])
+        separate = [float(r.integrate(f, 0.0, 1.0, ())[1]) for f in funs]
+        np.testing.assert_allclose(
+            combined, max(separate), rtol=ULP_RTOL, atol=ULP_ATOL
+        )
+
+
+# The tanh-sinh rule is the only one that leaves part of the interval unsampled, and the
+# tests below are about that gap. The other two are interpolatory over the whole of
+# ``[a, b]``: their weights are fixed by requiring that polynomials up to some degree be
+# integrated exactly over the closed interval, so the strip between the outermost node
+# and the endpoint is already accounted for by the outermost weight, however far in that
+# node happens to sit. A tanh-sinh rule is instead the trapezoidal rule for an integral
+# over the whole real line in the mapped variable, cut off at a finite ``t``, and the
+# terms past the cutoff carry mass that nothing in the rule compensates for.
+
+
+def _tanhsinh_errors(fun, a, b, orders=TANHSINH_ORDERS):
+    """Reported error of the tanh-sinh rule at each of ``orders``."""
+    return [float(TanhSinhRule(order=o).integrate(fun, a, b, ())[1]) for o in orders]
+
+
+class TestTanhSinhTruncation:
+    """The mass beyond the outermost node is charged to the error estimate."""
+
+    def test_raising_the_order_does_not_clear_an_endpoint_singularity(self):
+        """Refining the mesh in ``t`` cannot shrink the sliver the map leaves out.
+
+        On an analytic integrand the estimate falls away to the roundoff floor as the
+        order rises, since the only error left is the trapezoidal one and that is what
+        more nodes buy. On an integrand singular at an endpoint the omitted sliver
+        carries real mass, the cutoff sits where it sits whatever the order, and the
+        estimate has to keep saying so. The two behaviors are separated by more than
+        ten orders of magnitude, so this measures the distinction rather than a rate.
+        """
+        orders = [21, 101]
+        analytic = _tanhsinh_errors(_exp_fun, 0.0, 1.0, orders)
+        singular = _tanhsinh_errors(lambda x: x**-0.9, 0.0, 1.0, orders)
+
+        assert analytic[-1] / analytic[0] < 1e-9
+        assert singular[-1] / singular[0] > 1e-2
+        assert analytic[-1] < 1e-13
+        assert singular[-1] > 1.0
+
+    def test_a_barely_integrable_endpoint_still_gets_a_finite_bound(self):
+        """``x**-p`` leaves a finite mass unsampled for every ``p`` below one.
+
+        That mass is ``d**(1 - p) / (1 - p)`` over a gap of width ``d``: large as ``p``
+        approaches one, but bounded, and the estimate has to say how large rather than
+        give up.
+        """
+        for p in (0.9, 0.99, 0.999):
+            fun = lambda x, p=p: x**-p
+            y, err, _, _ = TanhSinhRule(order=61).integrate(fun, 0.0, 1.0, ())
+            true_err = abs(float(y) - 1 / (1 - p))
+            assert np.isfinite(float(err)), f"p={p}: reported a non-finite error"
+            assert true_err <= float(err), (
+                f"p={p}: reported {float(err):.3e} < true {true_err:.3e}"
+            )
+
+    def test_a_non_integrable_endpoint_is_reported_as_unbounded(self):
+        """``1/x`` on ``[0, 1]`` has no finite integral and so no finite error bound.
+
+        The rule returns a number regardless, since it only ever sees finite samples,
+        and an unbounded error is what says that number means nothing. This is the one
+        case that reports a non-finite error, and it is the honest report rather than a
+        gap in the estimate.
+        """
+        _, err, _, _ = TanhSinhRule(order=61).integrate(lambda x: 1 / x, 0.0, 1.0, ())
+        assert not np.isfinite(float(err))
+
+    def test_the_estimate_survives_a_node_rounding_onto_the_endpoint(self):
+        """A sub-interval far from the origin relative to its width is the worst case.
+
+        There the outermost nodes round onto the endpoint itself, an integrand singular
+        there is evaluated at the singularity, and the non-finite value it returns is
+        masked away. Read naively that says the outermost term is zero and so there is
+        no tail, which is exactly backwards: it is the case where the tail is largest.
+        """
+        fun = lambda x: 1 / jnp.sqrt(1 - x**2)
+        a, b = 0.5, 1.0
+        exact = np.arcsin(b) - np.arcsin(a)
+
+        for order in (21, 61, 101):
+            rule = TanhSinhRule(order=order)
+            # the premise of the test: the outermost node really has collapsed onto the
+            # endpoint, so it is the masking path being exercised and not the ordinary
+            # one. Without this the test would keep passing for the wrong reason if the
+            # node placement ever changed.
+            xh = rule._nodes_weights(jnp.float64)[0]
+            assert float((b + a) / 2 + (b - a) / 2 * xh[-1]) == b
+
+            y, err, _, _ = rule.integrate(fun, a, b, ())
+            true_err = abs(float(y) - exact)
+            assert true_err <= float(err), (
+                f"order {order}: reported {float(err):.3e} < true {true_err:.3e}"
+            )
+
+
 # The dtype of the limits is the statement of what precision the caller wants, and the
 # rules are a public entry point in their own right rather than only the inside of the
 # adaptive loop, so they have to honour it on their own.

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -177,7 +177,12 @@ class TestRichardsonFlag:
         # How far each column got: the length of its leading run of nonzeros. Counted
         # as a run rather than located as the first zero, because a column filled to
         # the end has no zero in it and a search would have to report its absence.
-        depth = min(*(int((c != 0).cumprod().sum()) for c in columns), self.DIVMAX)
+        # Row 0 is exempt: it is the trapezoidal rule on the two ends of the range
+        # alone, and under the tanh-sinh map both of those carry no weight, so a filled
+        # row 0 is legitimately zero and would end the run before it started.
+        depth = min(
+            *(1 + int((c[1:] != 0).cumprod().sum()) for c in columns), self.DIVMAX
+        )
         assert depth > 1, "neither setting filled the trapezoidal column"
         np.testing.assert_allclose(
             columns[0][:depth], columns[1][:depth], rtol=ULP_RTOL, atol=ULP_ATOL

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -424,9 +424,9 @@ class TestDivmin:
 
         With the tolerance zeroed every level runs, so the count is the sum over the
         schedule: the two endpoints directly, then the starting sweep's interior points
-        in padded batches, then each later level's new points in their own. One point at
-        a time nothing is padded and the sum collapses to the documented bound
-        ``2**divmax + 1``.
+        in padded batches, then each later level's new points in their own, plus
+        whatever the variant spends off the schedule. One point at a time nothing is
+        padded and the sum collapses to the documented bound.
         """
         divmax, divmin = 5, 3
         _, info = self._run(method, 0, divmin, divmax=divmax, batch_size=batch_size)

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -8,6 +8,7 @@ on a rule that converges without it. Romberg also takes ``divmax`` where they ta
 ``max_ninter``, and rejects breakpoints outright.
 """
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -332,8 +333,200 @@ class TestBatchSize:
 
 
 @pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+class TestInitialPoints:
+    """Starting the halving schedule from more than two points."""
+
+    DIVMAX = 8
+    TOL = 1e-10
+
+    def _run(self, method, i, initial_points, divmax=None, **kwargs):
+        """Run to a fixed depth with the tolerance zeroed, as in ``TestBatchSize``."""
+        prob = PROBLEMS[i]
+        return method(
+            prob["fun"],
+            jnp.asarray(prob["interval"], float),
+            epsabs=0.0,
+            epsrel=0.0,
+            divmax=divmax or self.DIVMAX,
+            full_output=True,
+            initial_points=initial_points,
+            **kwargs,
+        )
+
+    @pytest.mark.parametrize("k", [1, 2, 4], ids=str)
+    def test_power_of_two_start_is_the_default_run_shifted(self, method, k):
+        """Starting at 2**k + 1 points replays the default run from level k on.
+
+        A first level of 2**k intervals is the state the default schedule reaches
+        after k refinements, so carrying the default run k levels further covers the
+        same nodes: the evaluation counts come out identical, and the trapezoidal
+        columns agree row for row once shifted, the diagonals the algorithm actually
+        reads with them.
+
+        Only those two are compared. An extrapolation entry above the diagonal of the
+        started run has no counterpart in the default table, because Richardson
+        builds it from levels below it in the same table and the started run has k
+        fewer levels to draw on - its early rows are genuinely first rows, not copies.
+        What is compared differs by rounding alone, since the started run sums its
+        first row in one pass where the default accumulates it across k halvings.
+        """
+        want, want_info = self._run(method, SMOOTH_FINITE[0], 2, divmax=self.DIVMAX + k)
+        got, got_info = self._run(method, SMOOTH_FINITE[0], 2**k + 1)
+        assert int(got_info.neval) == int(want_info.neval)
+        tables = [np.asarray(o.info) for o in (got_info, want_info)]
+        depth = tables[0].shape[0]
+        rows = np.arange(depth)
+        np.testing.assert_allclose(
+            tables[0][:, 0], tables[1][k:, 0], rtol=1e-12, atol=1e-13
+        )
+        np.testing.assert_allclose(
+            tables[0][rows, rows], tables[1][rows + k, rows], rtol=1e-12, atol=1e-13
+        )
+
+    @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
+    @pytest.mark.parametrize("initial_points", [3, 5, 10, 17], ids=str)
+    def test_converges_from_an_arbitrary_start(self, method, i, initial_points):
+        """Starts that are not one more than a power of two converge all the same.
+
+        The claim is accuracy against the exact value at a tolerance the default run
+        meets comfortably, not agreement with another run of this same method, since
+        the question is whether a standalone halving sequence started anywhere at all
+        is sound.
+        """
+        prob = PROBLEMS[i]
+        y, info = method(
+            prob["fun"],
+            jnp.asarray(prob["interval"], float),
+            epsabs=self.TOL,
+            epsrel=self.TOL,
+            divmax=12,
+            initial_points=initial_points,
+        )
+        assert int(info.status) == 0
+        np.testing.assert_allclose(
+            np.asarray(y), np.asarray(prob["val"]), rtol=self.TOL, atol=self.TOL
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 4], ids=["serial", "batched"])
+    def test_neval_follows_the_schedule(self, method, batch_size):
+        """Level 0 places ``initial_points`` evaluations, level k places m*2**(k-1).
+
+        With the tolerance zeroed every level runs, so the count is the sum over the
+        schedule: the two endpoints directly plus the padded batches of the level 0
+        interior sum, then each level's new points in their own padded batches. One
+        point at a time nothing is padded and the sum collapses to the documented
+        bound ``(initial_points - 1)*2**divmax + 1``.
+        """
+        divmax, initial_points = 5, 10
+        m = initial_points - 1
+        _, info = self._run(
+            method, 0, initial_points, divmax=divmax, batch_size=batch_size
+        )
+        expected = (
+            2
+            + -(-(m - 1) // batch_size) * batch_size
+            + sum(
+                -(-(m * 2 ** (k - 1)) // batch_size) * batch_size
+                for k in range(1, divmax + 1)
+            )
+        )
+        assert int(info.neval) == expected
+        if batch_size == 1:
+            assert expected == m * 2**divmax + 1
+
+    def test_batch_size_is_clipped_to_the_deepest_level(self, method):
+        """No level places more than ``m*2**(divmax - 1)`` points; nothing above helps.
+
+        Mirrors the clip test for ``batch_size`` itself: without the clip a generous
+        batch size would be padding on every level of a shallow run, and ``neval``
+        would grow without the run doing any more work. The start multiplies into the
+        deepest level's point count, so it multiplies into the clip.
+        """
+        divmax, initial_points = 4, 9
+        deepest = (initial_points - 1) * 2 ** (divmax - 1)
+        _, clipped = self._run(
+            method, 0, initial_points, divmax=divmax, batch_size=10**6
+        )
+        _, exact = self._run(
+            method, 0, initial_points, divmax=divmax, batch_size=deepest
+        )
+        assert int(clipped.neval) == int(exact.neval)
+
+    def test_vector_valued(self, method):
+        """The mask has to broadcast against the integrand's own trailing axes."""
+        fun = lambda x: jnp.array([jnp.sin(x), jnp.cos(x), x**2])  # noqa: E731
+        interval = jnp.array([0.0, 1.0])
+        want, _ = method(fun, interval, divmax=self.DIVMAX, full_output=True)
+        got, _ = method(
+            fun, interval, divmax=self.DIVMAX, full_output=True, initial_points=13
+        )
+        np.testing.assert_allclose(
+            np.asarray(got), np.asarray(want), rtol=1e-10, atol=1e-12
+        )
+
+    def test_infinite_range(self, method):
+        """A wide start over a mapped infinite interval.
+
+        Level 0 then sums interior nodes of the mapped domain, which sit differently
+        from anything the default schedule visits, so this exercises the node formula
+        off the finite case. Both methods reach this problem: the exponential decay
+        is one the map turns into a smooth integrand, which is the setting Romberg is
+        for.
+        """
+        prob = PROBLEMS[12]  # gaussian-line, [0, inf)
+        y, info = method(
+            prob["fun"],
+            jnp.asarray(prob["interval"], float),
+            epsabs=1e-9,
+            epsrel=1e-9,
+            divmax=12,
+            initial_points=33,
+        )
+        assert int(info.status) == 0
+        np.testing.assert_allclose(
+            np.asarray(y), np.asarray(prob["val"]), rtol=1e-9, atol=1e-9
+        )
+
+    def test_gradient_does_not_depend_on_the_start(self, method):
+        """Reverse mode through the frozen-level adjoint agrees across starts.
+
+        ``DirectAdjoint`` freezes the number of levels the primal solve used and
+        differentiates that fixed linear functional of the integrand. A wider start
+        changes which functional that is, but on a problem every one of them resolves,
+        the derivatives they return are the continuous one to the accuracy of their
+        discretizations.
+        """
+        fun = lambda t, c: c * jnp.cos(t)  # noqa: E731
+
+        def grad_at(initial_points):
+            return jax.grad(
+                lambda a: method(
+                    fun,
+                    jnp.array([a, 1.0]),
+                    args=(2.0,),
+                    divmax=12,
+                    initial_points=initial_points,
+                )[0]
+            )(jnp.array(0.25))
+
+        want = -2.0 * jnp.cos(0.25)
+        np.testing.assert_allclose(grad_at(2), want, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(grad_at(17), want, rtol=1e-9, atol=1e-11)
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
 @pytest.mark.parametrize("batch_size", [0, -1, 2.5], ids=["zero", "negative", "float"])
 def test_bad_batch_size_rejected(method, batch_size):
     """A batch size that is not a positive integer is a mistake, not a default."""
     with pytest.raises(ValueError, match="batch_size"):
         method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), batch_size=batch_size)
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+@pytest.mark.parametrize(
+    "initial_points", [1, 0, -3, 2.5], ids=["one", "zero", "negative", "float"]
+)
+def test_bad_initial_points_rejected(method, initial_points):
+    """A starting grid smaller than two points, or not a count at all, is a mistake."""
+    with pytest.raises(ValueError, match="initial_points"):
+        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), initial_points=initial_points)

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -211,6 +211,10 @@ class TestBatchSize:
         exhausts ``divmax``. Without that a batch size could stop a level earlier or
         later than the serial run purely on the last-bit differences above, and the
         comparison would be between two different discretizations.
+
+        ``divmin=0`` starts from two points, so every level below ``divmax`` is placed
+        by the refinement loop and the schedule these tests count against is the loop's
+        alone. What the starting sweep does with a batch is ``TestDivmin``'s business.
         """
         prob = PROBLEMS[i]
         return method(
@@ -221,6 +225,7 @@ class TestBatchSize:
             divmax=divmax or self.DIVMAX,
             full_output=True,
             batch_size=batch_size,
+            divmin=0,
         )
 
     def _depth(self, info, batch_size):
@@ -283,8 +288,8 @@ class TestBatchSize:
         """
         self._assert_matches_serial(method, i, self.PADS)
 
-    def test_serial_is_the_default(self, method):
-        """``batch_size=None`` and ``batch_size=1`` are the same computation.
+    def test_serial_is_the_default_at_divmin_zero(self, method):
+        """``batch_size=None`` is ``2**divmin``, so at ``divmin=0`` it is one point.
 
         One point per batch leaves the mask always true and the sum over a single row,
         so no term is reordered and the two agree to roundoff rather than merely to
@@ -333,13 +338,13 @@ class TestBatchSize:
 
 
 @pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
-class TestInitialPoints:
-    """Starting the halving schedule from more than two points."""
+class TestDivmin:
+    """Starting the halving schedule several levels in."""
 
     DIVMAX = 8
     TOL = 1e-10
 
-    def _run(self, method, i, initial_points, divmax=None, **kwargs):
+    def _run(self, method, i, divmin, divmax=None, **kwargs):
         """Run to a fixed depth with the tolerance zeroed, as in ``TestBatchSize``."""
         prob = PROBLEMS[i]
         return method(
@@ -349,50 +354,56 @@ class TestInitialPoints:
             epsrel=0.0,
             divmax=divmax or self.DIVMAX,
             full_output=True,
-            initial_points=initial_points,
+            divmin=divmin,
             **kwargs,
         )
 
-    @pytest.mark.parametrize("k", [1, 2, 4], ids=str)
-    def test_power_of_two_start_is_the_default_run_shifted(self, method, k):
-        """Starting at 2**k + 1 points replays the default run from level k on.
+    @staticmethod
+    def _filled(table):
+        """Last row a run actually wrote.
 
-        A first level of 2**k intervals is the state the default schedule reaches
-        after k refinements, so carrying the default run k levels further covers the
-        same nodes: the evaluation counts come out identical, and the trapezoidal
-        columns agree row for row once shifted, the diagonals the algorithm actually
-        reads with them.
-
-        Only those two are compared. An extrapolation entry above the diagonal of the
-        started run has no counterpart in the default table, because Richardson
-        builds it from levels below it in the same table and the started run has k
-        fewer levels to draw on - its early rows are genuinely first rows, not copies.
-        What is compared differs by rounding alone, since the started run sums its
-        first row in one pass where the default accumulates it across k halvings.
+        Zeroing the tolerance does not quite pin the depth: the loop also stops when two
+        successive estimates agree to the last bit, so two runs can write different
+        numbers of rows and only the rows both filled can be compared.
         """
-        want, want_info = self._run(method, SMOOTH_FINITE[0], 2, divmax=self.DIVMAX + k)
-        got, got_info = self._run(method, SMOOTH_FINITE[0], 2**k + 1)
-        assert int(got_info.neval) == int(want_info.neval)
+        rows = [k for k in range(table.shape[0]) if np.any(table[k] != 0)]
+        return max(rows) if rows else 0
+
+    @pytest.mark.parametrize("divmin", [1, 2, 3, 5], ids=str)
+    @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
+    def test_table_matches_the_run_from_scratch(self, method, divmin, i):
+        """Starting `divmin` levels in builds the same table, not a shorter one.
+
+        The starting grid contains every coarser grid of the halving sequence, so the
+        rows below it are filled from the same evaluations, and the table is the one a
+        run from ``divmin=0`` holds at the same depth. That is the whole claim
+        ``divmin`` rests on: it moves where the evaluations are batched without moving
+        which extrapolations are available, which is what separates it from starting
+        the refinement on a finer mesh and leaving the coarse rows empty.
+
+        To rounding rather than exactly, for the reason batching is: the two accumulate
+        a level's points in a different order.
+        """
+        want, want_info = self._run(method, i, 0)
+        got, got_info = self._run(method, i, divmin)
         tables = [np.asarray(o.info) for o in (got_info, want_info)]
-        depth = tables[0].shape[0]
-        rows = np.arange(depth)
+        depth = min(self._filled(tables[0]), self._filled(tables[1]))
+        assert depth > divmin, "the run stopped inside its own starting sweep"
+        scale = max(np.max(np.abs(tables[1])), 1.0)
         np.testing.assert_allclose(
-            tables[0][:, 0], tables[1][k:, 0], rtol=1e-12, atol=1e-13
+            tables[0][: depth + 1],
+            tables[1][: depth + 1],
+            rtol=1e-11,
+            atol=1e-13 * scale,
         )
         np.testing.assert_allclose(
-            tables[0][rows, rows], tables[1][rows + k, rows], rtol=1e-12, atol=1e-13
+            np.asarray(got), np.asarray(want), rtol=1e-11, atol=1e-13 * scale
         )
 
     @pytest.mark.parametrize("i", SMOOTH_FINITE, ids=problem_id)
-    @pytest.mark.parametrize("initial_points", [3, 5, 10, 17], ids=str)
-    def test_converges_from_an_arbitrary_start(self, method, i, initial_points):
-        """Starts that are not one more than a power of two converge all the same.
-
-        The claim is accuracy against the exact value at a tolerance the default run
-        meets comfortably, not agreement with another run of this same method, since
-        the question is whether a standalone halving sequence started anywhere at all
-        is sound.
-        """
+    @pytest.mark.parametrize("divmin", [0, 1, 3, 6], ids=str)
+    def test_converges_from_any_start(self, method, i, divmin):
+        """Every start reaches a tolerance the default run meets comfortably."""
         prob = PROBLEMS[i]
         y, info = method(
             prob["fun"],
@@ -400,7 +411,7 @@ class TestInitialPoints:
             epsabs=self.TOL,
             epsrel=self.TOL,
             divmax=12,
-            initial_points=initial_points,
+            divmin=divmin,
         )
         assert int(info.status) == 0
         np.testing.assert_allclose(
@@ -409,69 +420,65 @@ class TestInitialPoints:
 
     @pytest.mark.parametrize("batch_size", [1, 4], ids=["serial", "batched"])
     def test_neval_follows_the_schedule(self, method, batch_size):
-        """Level 0 places ``initial_points`` evaluations, level k places m*2**(k-1).
+        """The starting sweep places ``2**divmin + 1`` points, level k places 2**(k-1).
 
         With the tolerance zeroed every level runs, so the count is the sum over the
-        schedule: the two endpoints directly plus the padded batches of the level 0
-        interior sum, then each level's new points in their own padded batches. One
-        point at a time nothing is padded and the sum collapses to the documented
-        bound ``(initial_points - 1)*2**divmax + 1``.
+        schedule: the two endpoints directly, then the starting sweep's interior points
+        in padded batches, then each later level's new points in their own. One point at
+        a time nothing is padded and the sum collapses to the documented bound
+        ``2**divmax + 1``.
         """
-        divmax, initial_points = 5, 10
-        m = initial_points - 1
-        _, info = self._run(
-            method, 0, initial_points, divmax=divmax, batch_size=batch_size
-        )
+        divmax, divmin = 5, 3
+        _, info = self._run(method, 0, divmin, divmax=divmax, batch_size=batch_size)
         expected = (
             2
-            + -(-(m - 1) // batch_size) * batch_size
+            + -(-(2**divmin - 1) // batch_size) * batch_size
             + sum(
-                -(-(m * 2 ** (k - 1)) // batch_size) * batch_size
-                for k in range(1, divmax + 1)
+                -(-(2 ** (k - 1)) // batch_size) * batch_size
+                for k in range(divmin + 1, divmax + 1)
             )
         )
         assert int(info.neval) == expected
         if batch_size == 1:
-            assert expected == m * 2**divmax + 1
+            assert expected == 2**divmax + 1
 
-    def test_batch_size_is_clipped_to_the_deepest_level(self, method):
-        """No level places more than ``m*2**(divmax - 1)`` points; nothing above helps.
+    def test_default_batch_covers_the_starting_sweep(self, method):
+        """``batch_size=None`` is ``2**divmin``: one batch for the whole start."""
+        divmin = 4
+        _, default = self._run(method, 0, divmin, batch_size=None)
+        _, explicit = self._run(method, 0, divmin, batch_size=2**divmin)
+        assert int(default.neval) == int(explicit.neval)
 
-        Mirrors the clip test for ``batch_size`` itself: without the clip a generous
-        batch size would be padding on every level of a shallow run, and ``neval``
-        would grow without the run doing any more work. The start multiplies into the
-        deepest level's point count, so it multiplies into the clip.
+    def test_batch_size_is_clipped_to_the_largest_level(self, method):
+        """Nothing above the largest number of points one level places helps.
+
+        Without the clip a generous batch size would be padding on every level of a
+        shallow run, and ``neval`` would grow without the run doing any more work. The
+        starting sweep counts as a level here, since for a deep start it is the largest.
         """
-        divmax, initial_points = 4, 9
-        deepest = (initial_points - 1) * 2 ** (divmax - 1)
-        _, clipped = self._run(
-            method, 0, initial_points, divmax=divmax, batch_size=10**6
-        )
-        _, exact = self._run(
-            method, 0, initial_points, divmax=divmax, batch_size=deepest
-        )
+        divmax, divmin = 4, 3
+        largest = max(2**divmin, 2 ** (divmax - 1))
+        _, clipped = self._run(method, 0, divmin, divmax=divmax, batch_size=10**6)
+        _, exact = self._run(method, 0, divmin, divmax=divmax, batch_size=largest)
         assert int(clipped.neval) == int(exact.neval)
 
     def test_vector_valued(self, method):
-        """The mask has to broadcast against the integrand's own trailing axes."""
+        """The masks have to broadcast against the integrand's own trailing axes."""
         fun = lambda x: jnp.array([jnp.sin(x), jnp.cos(x), x**2])  # noqa: E731
         interval = jnp.array([0.0, 1.0])
-        want, _ = method(fun, interval, divmax=self.DIVMAX, full_output=True)
-        got, _ = method(
-            fun, interval, divmax=self.DIVMAX, full_output=True, initial_points=13
-        )
+        want, _ = method(fun, interval, divmax=self.DIVMAX, full_output=True, divmin=0)
+        got, _ = method(fun, interval, divmax=self.DIVMAX, full_output=True, divmin=4)
         np.testing.assert_allclose(
             np.asarray(got), np.asarray(want), rtol=1e-10, atol=1e-12
         )
 
     def test_infinite_range(self, method):
-        """A wide start over a mapped infinite interval.
+        """A deep start over a mapped infinite interval.
 
-        Level 0 then sums interior nodes of the mapped domain, which sit differently
-        from anything the default schedule visits, so this exercises the node formula
-        off the finite case. Both methods reach this problem: the exponential decay
-        is one the map turns into a smooth integrand, which is the setting Romberg is
-        for.
+        The starting sweep then places interior nodes of the mapped domain, so this
+        exercises the node formula off the finite case. Both methods reach this problem:
+        the exponential decay is one the map turns into a smooth integrand, which is the
+        setting Romberg is for.
         """
         prob = PROBLEMS[12]  # gaussian-line, [0, inf)
         y, info = method(
@@ -480,7 +487,7 @@ class TestInitialPoints:
             epsabs=1e-9,
             epsrel=1e-9,
             divmax=12,
-            initial_points=33,
+            divmin=5,
         )
         assert int(info.status) == 0
         np.testing.assert_allclose(
@@ -491,27 +498,23 @@ class TestInitialPoints:
         """Reverse mode through the frozen-level adjoint agrees across starts.
 
         ``DirectAdjoint`` freezes the number of levels the primal solve used and
-        differentiates that fixed linear functional of the integrand. A wider start
-        changes which functional that is, but on a problem every one of them resolves,
-        the derivatives they return are the continuous one to the accuracy of their
-        discretizations.
+        differentiates that fixed linear functional of the integrand. A deeper start
+        can settle on a different number of them, but on a problem every one of them
+        resolves, the derivatives they return are the continuous one to the accuracy of
+        their discretizations.
         """
         fun = lambda t, c: c * jnp.cos(t)  # noqa: E731
 
-        def grad_at(initial_points):
+        def grad_at(divmin):
             return jax.grad(
                 lambda a: method(
-                    fun,
-                    jnp.array([a, 1.0]),
-                    args=(2.0,),
-                    divmax=12,
-                    initial_points=initial_points,
+                    fun, jnp.array([a, 1.0]), args=(2.0,), divmax=12, divmin=divmin
                 )[0]
             )(jnp.array(0.25))
 
         want = -2.0 * jnp.cos(0.25)
-        np.testing.assert_allclose(grad_at(2), want, rtol=1e-9, atol=1e-11)
-        np.testing.assert_allclose(grad_at(17), want, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(grad_at(0), want, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(grad_at(5), want, rtol=1e-9, atol=1e-11)
 
 
 @pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
@@ -523,10 +526,23 @@ def test_bad_batch_size_rejected(method, batch_size):
 
 
 @pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
-@pytest.mark.parametrize(
-    "initial_points", [1, 0, -3, 2.5], ids=["one", "zero", "negative", "float"]
-)
-def test_bad_initial_points_rejected(method, initial_points):
-    """A starting grid smaller than two points, or not a count at all, is a mistake."""
-    with pytest.raises(ValueError, match="initial_points"):
-        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), initial_points=initial_points)
+@pytest.mark.parametrize("divmin", [-1, -3, 2.5], ids=["minusone", "negative", "float"])
+def test_bad_divmin_rejected(method, divmin):
+    """A start that is not a count of halvings is a mistake, not a default."""
+    with pytest.raises(ValueError, match="divmin"):
+        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), divmin=divmin)
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+@pytest.mark.parametrize("divmax", [-1, -3, 2.5], ids=["minusone", "negative", "float"])
+def test_bad_divmax_rejected(method, divmax):
+    """A divmax that is not a count of halvings is a mistake, not a default."""
+    with pytest.raises(ValueError, match="divmax"):
+        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), divmax=divmax)
+
+
+@pytest.mark.parametrize("method", METHODS, ids=METHOD_IDS)
+def test_divmin_above_divmax_rejected(method):
+    """Starting below the floor the run is allowed to reach is a contradiction."""
+    with pytest.raises(ValueError, match="divmin"):
+        method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), divmin=6, divmax=4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,11 +24,6 @@ class TestMapping:
         """No normalization to [-1, 1], so only one affine map reaches the nodes."""
         _, interval_t = map_interval(lambda x: x, jnp.array([2.0, 3.5, 5.0]))
         np.testing.assert_array_equal(np.asarray(interval_t), [2.0, 3.5, 5.0])
-        # the one caller that needs the reference interval can still ask for it
-        _, interval_r = map_interval(
-            lambda x: x, jnp.array([2.0, 3.5, 5.0]), reference=True
-        )
-        np.testing.assert_allclose(np.asarray(interval_r), [-1.0, 0.0, 1.0])
 
     def test_an_infinite_interval_is_mapped(self):
         """There is no way to subdivide an unbounded interval in place."""


### PR DESCRIPTION
- ``quadts`` and ``TanhSinhRule`` now account for the mass lying beyond their
    outermost node. A tanh-sinh rule is the trapezoidal rule for an integral over the
    whole real line in the mapped variable, cut off at a finite range, and the terms
    past that cutoff carry mass no other weight compensates for. On a bounded integrand
    the omitted mass is at the level of roundoff and nothing changes; on one singular
    at an endpoint it can be the whole of the error. Reported ``err`` values and
    sub-interval counts change on such integrands, and runs that used to report
    success while missing the requested tolerance now report a non-zero status.
- ``rombergts``'s reported ``err`` now accounts for the mass its tanh-sinh map leaves
    outside the range it integrates over. That mass is fixed by the map rather than by
    the mesh, so refining converges onto it and the level-to-level movement the estimate
    was built from says nothing about it. Runs that cannot reach the requested tolerance
    because of it now say so rather than reporting success, and stop once refining can
    no longer help instead of spending the rest of ``divmax`` budget.
- ``romberg`` and ``rombergts`` take a new ``divmin`` argument, default 4. It sets what
    refinement level the solver starts at (number of initial intervals = ``2**divmin``),
    with the old behavior corresponding to ``divmin=0``. The new default is more efficient
    on accelerators, and is generally more robust against false early termination, with a
    small increase in cost on extremely simple integrands.