### PR TITLE
Add open version of Clenshaw-Curtis rule

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -28,12 +28,11 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -v --durations=0 --cov-report xml:cov.xml --cov-config=pyproject.toml --cov=quadax/ --db ./prof.db
-      - name: save coverage file and plot comparison results
+          python -m pytest -v --durations=0 --cov-report xml:cov.xml --cov-config=pyproject.toml --cov=quadax/
+      - name: save coverage file
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: unit_test_artifact_${{ matrix.python-version }}
           path: |
             ./cov.xml
-            ./prof.db

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -40,15 +40,14 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -v --durations=0 --cov-report xml:cov.xml --cov-config=pyproject.toml --cov=quadax/ --db ./prof.db
-      - name: save coverage file and plot comparison results
+          python -m pytest -v --durations=0 --cov-report xml:cov.xml --cov-config=pyproject.toml --cov=quadax/
+      - name: save coverage file
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: unit_test_artifact_${{ matrix.python-version }}
           path: |
             ./cov.xml
-            ./prof.db
       - name: Upload coverage
         id : codecov
         uses: codecov/codecov-action@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.402
+    rev: v1.1.411
     hooks:
     - id: pyright
       additional_dependencies: ["jax", "equinox", "pytest"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ v0.3.0
     was built from says nothing about it. Runs that cannot reach the requested tolerance
     because of it now say so rather than reporting success, and stop once refining can
     no longer help instead of spending the rest of ``divmax`` budget.
+- Added an open variant of the Clenshaw-Curtis rule. ``ClenshawCurtisRule`` and
+  ``quadcc`` take a new ``closed`` argument, defaulting to ``True``, which keeps the
+  existing closed rule. With ``closed=False`` the rule uses the Fejer-2 nodes: the same
+  ``cos(k*pi/order)`` family with the two endpoints dropped, ``order - 1`` points exact
+  to degree ``order - 1``, and the same 2:1 nesting against an embedded ``order // 2``
+  rule.
+  - The open variant is much cheaper on infinite intervals whose integrand decays
+  algebraically or for integrands that are singular at an endpoint.
+  - The closed rule remains the default and is the cheaper of the two on smooth, peaked
+    and oscillatory integrands, by up to about a factor of two in evaluations.
+- ``ClenshawCurtisRule``, ``TanhSinhRule``, ``quadcc``, and ``quadts`` now raise an
+  error on an order that would build a malformed rule, rather than silently changing
+  the order.
 - **Breaking**: removed ``fixed_quadgk``, ``fixed_quadcc``, and ``fixed_quadts``,
   deprecated since v0.2.2. Use ``GaussKronrodRule``, ``ClenshawCurtisRule``, and
   ``TanhSinhRule`` instead, eg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ test = [
   "scipy >= 1.10.0, <= 1.17",
   "pytest >= 5.0.0, < 9.2",
   "pytest-cov >= 2.6, < 7.2",
-  "pytest-monitor < 1.7",
 ]
 docs = [
   "sphinx >= 3.0.0, < 9.2",

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -204,6 +204,7 @@ def quadcc(
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = True,
     batch_size: int | None = None,
+    closed: bool = True,
 ):
     """Global adaptive quadrature using Clenshaw-Curtis rule.
 
@@ -240,8 +241,9 @@ def quadcc(
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
-    order : {8, 16, 32, 64, 128, 256}
-        Order of local integration rule.
+    order : int
+        Order of local integration rule. Must be a multiple of 4, or with
+        ``closed=False`` any even order of at least 4; see ``ClenshawCurtisRule``.
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -267,6 +269,13 @@ def quadcc(
         Values larger than the number of nodes are clipped to it. In a gradient the
         adjoint evaluates several sub-intervals together, so the width there is
         ``batch_size`` times the adjoint's own ``chunk_size``.
+    closed : bool, optional
+        Whether the interval endpoints are among the nodes of the local rule. The
+        default closed rule is cheaper on smooth, peaked and oscillatory integrands. The
+        open (Fejer-2) rule never evaluates the integrand at an interval endpoint, which
+        is what to use for integrands that are singular or undefined there; it is
+        markedly cheaper on infinite intervals whose integrand decays algebraically,
+        and on endpoint singularities. See ``ClenshawCurtisRule``.
 
     Returns
     -------
@@ -305,7 +314,7 @@ def quadcc(
     needs is the binding constraint instead.
 
     """
-    rule = ClenshawCurtisRule(order, norm, batch_size)
+    rule = ClenshawCurtisRule(order, norm, batch_size, closed)
     y, info = adaptive_quadrature(
         rule,
         fun,
@@ -373,8 +382,8 @@ def quadts(
     max_ninter : int, optional
         An upper bound on the number of sub-intervals used in the adaptive
         algorithm.
-    order : {41, 61, 81, 101}
-        Order of local integration rule.
+    order : int
+        Order of local integration rule. Must be odd.
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -8,7 +8,12 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from .quad_weights import get_cc_table, get_tanhsinh_table, gk_weights
+from .quad_weights import (
+    get_cc_table,
+    get_fejer2_table,
+    get_tanhsinh_table,
+    gk_weights,
+)
 from .utils import _real_dtype, check_size, tanhsinh_tmax, wrap_func
 
 
@@ -455,7 +460,8 @@ class ClenshawCurtisRule(NestedRule):
     Parameters
     ----------
     n : int
-        Order of integration scheme. Must be even.
+        Order of integration scheme. Must be a multiple of 4 with ``closed=True``, or
+        any even order of at least 4 with ``closed=False``.
     norm : int, callable
         Norm to use for measuring error for vector valued integrands. No effect if the
         integrand is scalar valued. If an int, uses p-norm of the given order, otherwise
@@ -467,13 +473,25 @@ class ClenshawCurtisRule(NestedRule):
         does not divide the number of nodes leaves a remainder, which is evaluated
         together in one smaller batch, so the integrand is traced twice but never
         evaluated at more points than the rule has nodes.
+    closed : bool, optional
+        Whether the interval endpoints are among the nodes. The default closed rule uses
+        ``order + 1`` points and is exact to degree ``order``. The open (Fejer-2) rule
+        uses the same node family with the endpoints dropped, giving ``order - 1``
+        points exact to degree ``order - 1``, and never evaluates the integrand at ``a``
+        or ``b``. Both nest 2:1 against an embedded ``order // 2`` rule.
 
     Notes
     -----
     On integrands with an endpoint singularity the error estimate can under-state the
     true error, increasingly so at higher order, because the endpoint-clustered nodes
     make the two rules agree while neither has converged. An adaptive integration may
-    then report success while missing the requested tolerance.
+    then report success while missing the requested tolerance. This applies to both
+    variants; the clustering is a property of the node family, not of the endpoints.
+
+    Which is cheaper depends on the integrand. The closed rule wins on smooth, peaked
+    and oscillatory ones, by up to about a factor of two in evaluations; the open rule
+    wins on endpoint singularities and by a wide margin on infinite intervals whose
+    integrand decays algebraically.
     """
 
     def __init__(
@@ -481,10 +499,10 @@ class ClenshawCurtisRule(NestedRule):
         order: int = 32,
         norm: Callable | float | int = jnp.inf,
         batch_size: int | None = None,
+        closed: bool = True,
     ):
         self._norm = norm
-        order = 2 * (order // 2)  # make sure its even
-        xh, wh, wl = get_cc_table(order)
+        xh, wh, wl = (get_cc_table if closed else get_fejer2_table)(order)
         self._xh, self._wh, self._wl = jnp.asarray(xh), jnp.asarray(wh), jnp.asarray(wl)
         check_size(batch_size)
         self._batch_size = (
@@ -537,7 +555,7 @@ class TanhSinhRule(NestedRule):
         batch_size: int | None = None,
     ):
         self._norm = norm
-        self._order = 2 * (order // 2) + 1  # make sure its odd
+        self._order = order
         # The stored table is the one for the default dtype; `_nodes_weights` rebuilds
         # it whenever the quadrature actually runs at a different precision.
         xh, wh, wl = get_tanhsinh_table(

--- a/quadax/quad_weights.py
+++ b/quadax/quad_weights.py
@@ -4,6 +4,8 @@ import functools
 
 import numpy as np
 
+from .utils import errorif
+
 kronrod_15_weights = np.array(
     [
         2.29353220105292249637320080589695919936e-2,
@@ -772,6 +774,34 @@ gk_weights = {
 }
 
 
+def _check_chebyshev_order(order: int, rule: str, multiple: int):
+    """Reject an order that would build a malformed rule, for both Chebyshev tables.
+
+    Both node sets are formed on the half interval and reflected, so that they come out
+    symmetric by construction rather than by the rounding of ``cos`` happening to agree
+    on both sides. An odd order leaves that reflection a node short, and the resulting
+    weights do not integrate a constant, so the rule returns a wrong integral rather
+    than merely a coarse one. Below order 4 there are too few points for the embedded
+    rule the error estimate is a difference against to exist at all.
+
+    ``multiple`` is what the caller's own orders step by, so that the orders offered as
+    a way out are ones it will accept rather than merely even.
+    """
+    errorif(
+        order < 4,
+        ValueError,
+        f"{rule} needs an order of at least 4 to have an embedded rule to estimate "
+        f"error against, got order={order}.",
+    )
+    errorif(
+        order % multiple != 0,
+        ValueError,
+        f"{rule} needs order to be a multiple of {multiple}, got order={order}. "
+        f"Use order={multiple * (order // multiple)} or "
+        f"order={multiple * (order // multiple + 1)}.",
+    )
+
+
 @functools.lru_cache
 def get_cc_table(order: int):
     """Clenshaw-Curtis nodes and weights, built in float64 on the host.
@@ -779,7 +809,10 @@ def get_cc_table(order: int):
     In numpy rather than with ``jnp`` ops so that the table does not inherit whatever
     the JAX default dtype happens to be. Building the DCT matrix in float32 and using it
     in float32 is strictly worse than building it in float64 and rounding it once.
+
+    ``order`` must be a multiple of 4; see ``_check_chebyshev_order``.
     """
+    _check_chebyshev_order(order, "The closed Clenshaw-Curtis rule", 4)
 
     def _cc_get_weights(N):
         d = 2 / (1 - np.arange(0, N + 1, 2, dtype=float) ** 2)
@@ -807,12 +840,54 @@ def get_cc_table(order: int):
 
 
 @functools.lru_cache
+def get_fejer2_table(order: int):
+    """Fejer-2 nodes and weights, built in float64 on the host.
+
+    The open counterpart of ``get_cc_table``: the same ``cos(k*pi/order)`` family with
+    the two endpoints dropped, so no node falls on the interval boundary. The 2:1
+    nesting is retained, the order ``order // 2`` rule sitting on the even numbered
+    nodes.
+
+    In numpy rather than with ``jnp`` ops for the same reason as ``get_cc_table``.
+
+    ``order`` must be even and at least 4; see ``_check_chebyshev_order``. Unlike the
+    closed table this one has no further requirement, its node index starting at 1 so
+    that the reflection recovers the coarse nodes the half interval table leaves out.
+    """
+    _check_chebyshev_order(order, "The open Clenshaw-Curtis (Fejer-2) rule", 2)
+
+    def _fejer2_get_weights(N):
+        # Only the k <= N/2 half is formed, and the caller reflects it, so that the
+        # node set comes out symmetric by construction rather than by the rounding of
+        # cos happening to agree on both sides.
+        k = np.arange(1, N // 2 + 1)
+        t = k * np.pi / N
+        j = np.arange(1, N // 2 + 1)
+        w = 4 / N * np.sin(t) * (np.sin(np.outer(t, 2 * j - 1)) / (2 * j - 1)).sum(1)
+        return np.cos(t), w
+
+    xh, wh = _fejer2_get_weights(order)
+    wl = np.zeros_like(wh)
+    # The coarse rule occupies the even numbered nodes, which sit at odd indices here
+    # because k starts at 1 rather than at 0 as it does for the closed rule.
+    wl[1::2] = _fejer2_get_weights(order // 2)[1]
+
+    return (
+        np.concatenate([xh, -xh[:-1][::-1]]),
+        np.concatenate([wh, wh[:-1][::-1]]),
+        np.concatenate([wl, wl[:-1][::-1]]),
+    )
+
+
+@functools.lru_cache
 def get_tanhsinh_table(order: int, tmax: float):
     """Tanh-sinh nodes and weights on ``[-tmax, tmax]``, built in float64 on the host.
 
     ``tmax`` is a parameter rather than being derived here because it depends on the
     precision the nodes will be *used* at; see ``quadax.utils.tanhsinh_tmax``.
     """
+    errorif(order % 2 != 1, ValueError, "tanh-sinh order must be odd")
+
     _xts = lambda t: np.tanh(np.pi / 2 * np.sinh(t))
     _wts = lambda t: np.pi / 2 * np.cosh(t) / np.cosh(np.pi / 2 * np.sinh(t)) ** 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,19 @@ def quiet_tanhsinh():
 # Freeing the caches is not sufficient on its own. glibc keeps the freed pages on its
 # own free lists instead of returning them, so RSS - which is what a runner's memory
 # limit measures - only falls once malloc_trim hands them back.
-SWEEP_RSS_MB = 1500
+#
+# The trigger is a fraction of the memory this process is allowed rather than a fixed
+# size, because a sweep can only ever free the caches: whatever the interpreter, the
+# JAX build and its loaded libraries hold is a floor that RSS cannot go below. That
+# floor differs several fold across the JAX versions the suite is tested against, and
+# a threshold set anywhere near it degenerates - every test sweeps, none of them frees
+# anything, and the run pays both the sweep and the recompilation that follows it for
+# no reduction in the working set. Sizing the trigger against the machine keeps it
+# clear of the floor on any build that fits in memory at all.
+SWEEP_RSS_FRACTION = 0.25
+
+# Used when the memory available to the process cannot be determined.
+SWEEP_RSS_MB_DEFAULT = 4000
 
 # Used only when RSS cannot be read, so that the sweep still happens on platforms
 # without procfs.
@@ -102,6 +114,47 @@ def _rss_mb():
             return int(f.read().split()[1]) * _PAGE_SIZE / 1e6
     except OSError:
         return None
+
+
+def _memory_limit_mb():
+    """Memory this process may use in MB, or None where it cannot be determined.
+
+    A cgroup limit takes precedence over the machine's total memory, since inside a
+    container it is the limit that kills the process rather than exhausting the host.
+    """
+    limits = []
+    for path in (
+        "/sys/fs/cgroup/memory.max",  # cgroup v2
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # cgroup v1
+    ):
+        try:
+            with open(path) as f:
+                limits.append(int(f.read().strip()) / 1e6)
+        except (OSError, ValueError):
+            # No cgroup, or v2 spelling its absence of a limit as "max".
+            continue
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    limits.append(int(line.split()[1]) / 1e3)
+                    break
+    except (OSError, IndexError, ValueError):
+        pass
+
+    # An unlimited cgroup v1 reports a sentinel near the top of the address space
+    # rather than omitting the value, so discard anything implausibly large and let
+    # the machine total stand instead.
+    limits = [limit for limit in limits if 0 < limit < 1e9]
+    return min(limits) if limits else None
+
+
+_MEMORY_LIMIT_MB = _memory_limit_mb()
+SWEEP_RSS_MB = (
+    SWEEP_RSS_MB_DEFAULT
+    if _MEMORY_LIMIT_MB is None
+    else SWEEP_RSS_FRACTION * _MEMORY_LIMIT_MB
+)
 
 
 def _release_memory():

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -29,7 +29,7 @@ import pytest
 import scipy.special
 from jax import config
 
-from quadax import STATUS
+from quadax import STATUS, quadcc
 
 config.update("jax_enable_x64", True)
 
@@ -847,6 +847,18 @@ def solve_once(method, i, tol, *, interval_as_array=False, **kwargs):
     return _SOLVED[key]
 
 
+def quadcc_open(*args, **kwargs):
+    """``quadcc`` using the open (Fejer-2) local rule.
+
+    A named function rather than a ``functools.partial`` because the tables below key
+    on ``__name__``, and the two variants of the rule have to be distinguishable there.
+    They are separate quadratures with their own sets of problems they can and cannot
+    solve, so the open one is swept in its own right rather than assumed to inherit the
+    closed rule's entries.
+    """
+    return quadcc(*args, closed=False, **kwargs)
+
+
 # Problems the routines do not reach the requested tolerance on, as (routine, problem)
 # pointing at the tolerances that fail. An entry says only that `assert_converged` does
 # not hold: the run did not report success, or reported it without the accuracy to back
@@ -889,8 +901,8 @@ def solve_once(method, i, tol, *, interval_as_array=False, **kwargs):
 # allowed the same number of sub-intervals as the default `max_ninter` the quadax runs
 # use. Where the note names tolerances, scipy fails at those and delivers at the others.
 #
-# 35 of the 44 convergence entries carry the note at one tolerance or more, and 2 of
-# the 5 dishonesty entries. That is the useful part of the annotation. An unmarked
+# 41 of the 50 convergence entries carry the note at one tolerance or more, and 3 of
+# the 7 dishonesty entries. That is the useful part of the annotation. An unmarked
 # entry is one where a widely used routine does solve the problem, so the shortfall is
 # quadax's; a marked one says the integrand is hard for the method rather than badly
 # implemented here, and `scipy.integrate.tanhsinh` failing on much the same set as
@@ -907,6 +919,12 @@ KNOWN_FAILURES = {
     ("quadcc", "osc-tail"): {1e-4, 1e-8},  # scipy too
     ("quadcc", "sin-inverse"): {1e-4, 1e-8},  # scipy too
     ("quadcc", "sqrt-tan"): {1e-4, 1e-8, 1e-12},
+    ("quadcc_open", "loglog"): {1e-4, 1e-8},  # scipy too
+    ("quadcc_open", "loglog-cube"): {1e-4, 1e-8},  # scipy too
+    ("quadcc_open", "loglog-right"): {1e-4, 1e-8},  # scipy too
+    ("quadcc_open", "loglog-sqrt"): {1e-4, 1e-8},  # scipy too
+    ("quadcc_open", "osc-tail"): {1e-4, 1e-8},  # scipy too
+    ("quadcc_open", "sin-inverse"): {1e-4, 1e-8},  # scipy too
     ("quadgk", "loglog"): {1e-4, 1e-8},  # scipy too
     ("quadgk", "loglog-cube"): {1e-4, 1e-8},  # scipy too
     ("quadgk", "loglog-right"): {1e-4, 1e-8},  # scipy too
@@ -961,9 +979,19 @@ KNOWN_FAILURES = {
 # The one `quadts` entry left is dishonest by 1.07x, the estimate of the mass its map
 # leaves outside the range it integrates over being sharp enough to leave nothing over
 # for the rest of the error.
+#
+# The `quadcc_open` `exp-over-sqrt` entry is the acceleration's estimate rather than the
+# rule's: with `extrapolate=False` the open rule is honest on that problem at every
+# tolerance. It understates by 3.5x, and only over a narrow band of requested
+# tolerances, the ones the subdivision happens to stop at that mesh for. Either side of
+# the band the loop takes another level and the estimate covers the error again, so
+# which tolerances are listed is a property of where the run stops and may differ by
+# host in the way the marked entries above do.
 KNOWN_DISHONEST: dict[tuple[str, str], set[float]] = {
     ("quadcc", "loglog-cube"): {1e-4},  # scipy too
     ("quadcc", "sqrt-tan"): {1e-12},
+    ("quadcc_open", "exp-over-sqrt"): {1e-8},  # 3.5x, the acceleration's estimate
+    ("quadcc_open", "loglog-cube"): {1e-4},  # scipy too
     ("quadgk", "loglog"): {1e-4},  # host dependent
     ("quadgk", "loglog-cube"): {1e-4},  # scipy too
     ("quadts", "decay-line"): {1e-8},  # 1.07x, the tail estimate has no margin

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -38,6 +38,7 @@ from .problems import (
     complex_dtypes,
     exp_neg,
     problem_id,
+    quadcc_open,
     real_dtypes,
     real_of,
     solve_once,
@@ -48,7 +49,7 @@ from .problems import (
 config.update("jax_enable_x64", True)
 
 
-METHODS = [(quadgk, "gk"), (quadcc, "cc"), (quadts, "ts")]
+METHODS = [(quadgk, "gk"), (quadcc, "cc"), (quadcc_open, "cc-open"), (quadts, "ts")]
 
 
 def accelerates(method):

--- a/tests/test_fixed_order.py
+++ b/tests/test_fixed_order.py
@@ -6,7 +6,9 @@ Each rule has a defining property, and these tests pin it down:
   an ``order // 2`` point Gauss rule, exactly integrating all polynomials up to degree
   ``3 * (order // 2) + 1`` (22, 31, 46, 61, 76, 91 for the six QUADPACK orders, i.e.
   ``~3/2 the order``).
-- ``ClenshawCurtisRule`` exactly integrates all polynomials up to degree ``order``.
+- ``ClenshawCurtisRule`` exactly integrates all polynomials up to degree
+  ``order``, or ``order - 1`` for the open (``closed=False``) variant, whose
+  defining property is that no node lands on an interval endpoint.
 - ``TanhSinhRule`` is a doubly-exponential trapezoidal rule: for analytic integrands
   each doubling of the order raises the error to a power near two once inside the
   asymptotic tail, which is far faster than any algebraic convergence rate.
@@ -26,6 +28,9 @@ The rules are a public entry point in their own right rather than only the insid
 adaptive loop, so the last section here checks that they honour the dtype of the limits
 on their own, without a solver around them.
 """
+
+import functools
+import re
 
 import jax.numpy as jnp
 import numpy as np
@@ -51,6 +56,11 @@ NOT_EXACT = 1e-3
 # not centered on the origin so that the even/odd symmetry of the node tables (which
 # would integrate odd integrands to zero for free) cannot hide anything.
 INTERVALS = [(-1.0, 1.0), (1.7, 3.9), (-1.0, 2.0)]
+
+# ``closed=False`` is a different quadrature rule sharing a class with the default one,
+# so it is bound here as its own callable and threaded through every test that sweeps
+# the rules, rather than being covered only where it is named explicitly.
+OpenClenshawCurtisRule = functools.partial(ClenshawCurtisRule, closed=False)
 
 
 def chebyshev(degree, x):
@@ -155,6 +165,95 @@ class TestClenshawCurtisPolynomialExactness:
         """The first even degree past ``order`` is not integrated exactly."""
         k = order + 2
         assert_not_exact(ClenshawCurtisRule(order=order), interval, k, NOT_EXACT)
+
+
+# Three widely separated orders rather than the closed rule's full list: the open
+# table is built by the same construction at every order, and what a sweep buys here
+# is the low, middle and high end of it.
+OPEN_ORDERS = [16, 64, 256]
+
+
+@pytest.mark.parametrize("order", OPEN_ORDERS)
+class TestOpenClenshawCurtis:
+    """``closed=False`` swaps in the Fejer-2 rule: the same nodes, minus the endpoints.
+
+    Two points are given up relative to the closed rule, so the degree of exactness
+    drops from ``order`` to ``order - 1``, but nothing else about the rule changes: it
+    is still an interpolatory rule on Chebyshev nodes with an embedded ``order // 2``
+    rule on every second node.
+    """
+
+    @pytest.mark.parametrize("interval", INTERVALS)
+    def test_exactness_is_one_degree_below_the_closed_rule(self, order, interval):
+        """Exact to degree ``order - 1``, and not to the even degree past it."""
+        rule = OpenClenshawCurtisRule(order=order)
+        for k in range(order):
+            assert_exact(rule, interval, k, MACHINE_PRECISION)
+        assert_not_exact(rule, interval, order, NOT_EXACT)
+
+
+# ---------------------------------------------------------------------------
+# Order validity
+# ---------------------------------------------------------------------------
+
+# Every order, odd ones included, over a range wide enough for the pattern to repeat
+# several times, taken well below 4 so the too-small end is covered as well. Swept
+# inside the tests rather than parametrized over, since what is under test is the
+# accepted set as a whole and not any one order.
+CANDIDATE_ORDERS = list(range(-2, 40))
+
+
+@pytest.mark.parametrize("closed", [True, False], ids=["closed", "open"])
+def test_exactly_the_workable_orders_are_accepted(closed):
+    """Nothing accepted is malformed, and nothing rejected would have worked."""
+    accepted = []
+    for order in CANDIDATE_ORDERS:
+        try:
+            rule = ClenshawCurtisRule(order=order, closed=closed)
+        except ValueError:
+            continue
+        accepted.append(order)
+        for name, w in (("wh", rule._wh), ("wl", rule._wl)):
+            np.testing.assert_allclose(
+                float(jnp.sum(w)),
+                2.0,
+                atol=1e-14,
+                err_msg=f"order {order} accepted with a malformed {name}",
+            )
+    step = 4 if closed else 2
+    assert accepted == [o for o in CANDIDATE_ORDERS if o >= 4 and o % step == 0]
+
+
+# One rejected order per cause, per variant. The two causes that leave a rule short of
+# a node - an odd order, and for the closed rule an even one whose half is odd, which
+# the open rule accepts - are both a failure to step by the variant's multiple, so they
+# share a message; they are still listed apart because they break different halves of
+# the nested pair.
+REJECTED = [
+    pytest.param(True, 2, "at least 4", id="closed-too-small"),
+    pytest.param(True, 9, "multiple of 4", id="closed-odd"),
+    pytest.param(True, 10, "multiple of 4", id="closed-odd-half"),
+    pytest.param(False, 2, "at least 4", id="open-too-small"),
+    pytest.param(False, 7, "multiple of 2", id="open-odd"),
+]
+
+
+@pytest.mark.parametrize("closed, order, reason", REJECTED)
+def test_the_error_names_the_reason_and_offers_an_order_that_works(
+    closed, order, reason
+):
+    """Each rejection says which requirement was missed and how to satisfy it.
+
+    The orders an error offers have to be ones the caller can actually use, which is
+    not the same as merely even: the two variants step by different amounts, so an
+    alternative suggested to a caller of the closed rule must clear its multiple-of-4
+    requirement rather than only being even. Below order 4 there is no larger
+    requirement to point at and no alternative is offered.
+    """
+    with pytest.raises(ValueError, match=reason) as excinfo:
+        ClenshawCurtisRule(order=order, closed=closed)
+    for alternative in re.findall(r"order=(\d+)", str(excinfo.value))[1:]:
+        ClenshawCurtisRule(order=int(alternative), closed=closed)
 
 
 def _exp_fun(x):
@@ -307,6 +406,7 @@ ERROR_CASES = {
 RULE_ORDERS = {
     "gk": (GaussKronrodRule, [15, 31, 61]),
     "cc": (ClenshawCurtisRule, [8, 32, 128]),
+    "cc-open": (OpenClenshawCurtisRule, [8, 32, 128]),
     "ts": (TanhSinhRule, [21, 61, 101]),
 }
 RULE_ORDER_PARAMS = [
@@ -319,13 +419,16 @@ RULE_ORDER_IDS = [
 # ``(rule, case) -> {orders}`` where the reported error comes out below the true one.
 # Kept as a table rather than folded into a tolerance so that the exceptions stay
 # countable, and so that one which starts passing shows up as an XPASS instead of
-# disappearing into the slack. The single entry is the endpoint singularity caveat in
+# disappearing into the slack. Both entries are the endpoint singularity caveat in
 # `ClenshawCurtisRule`'s own documentation: its nodes cluster at the endpoints, so the
 # two rules of the nested pair agree closely there while neither has resolved anything,
-# and the difference between them understates what is left. It clears as the order
-# rises, being 2.3x at order 8 and honest from order 32 on.
+# and the difference between them understates what is left. The clustering belongs to
+# the node family rather than to the endpoints themselves, so dropping them does not
+# help and the open variant is listed at the same order. It clears as the order rises,
+# being ~2x at order 8 and honest from order 32 on for both.
 RULE_KNOWN_DISHONEST: dict[tuple[str, str], set[int]] = {
     ("cc", "pow-0.9"): {8},
+    ("cc-open", "pow-0.9"): {8},
 }
 
 
@@ -336,13 +439,12 @@ def _rule_name(rule):
 
 def xfail_if_rule_dishonest(request, rule, order, case):
     """Mark the running test xfail if `RULE_KNOWN_DISHONEST` lists this case."""
-    orders = RULE_KNOWN_DISHONEST.get((_rule_name(rule), case))
+    name = _rule_name(rule)
+    orders = RULE_KNOWN_DISHONEST.get((name, case))
     if orders is not None and order in orders:
         request.applymarker(
             pytest.mark.xfail(
-                reason=(
-                    f"{rule.__name__} order {order} understates its error on {case}"
-                ),
+                reason=f"{name} order {order} understates its error on {case}",
                 strict=False,
             )
         )
@@ -499,14 +601,22 @@ class TestTanhSinhTruncation:
 # rules are a public entry point in their own right rather than only the inside of the
 # adaptive loop, so they have to honour it on their own.
 
-RULES = [GaussKronrodRule, ClenshawCurtisRule, TanhSinhRule]
+RULES = [
+    GaussKronrodRule,
+    ClenshawCurtisRule,
+    OpenClenshawCurtisRule,
+    TanhSinhRule,
+]
+# Given explicitly because the open rule is bound with `functools.partial`, which pytest
+# would otherwise number rather than name.
+RULE_IDS = ["gk", "cc", "cc-open", "ts"]
 
 
 @pytest.mark.usefixtures("quiet_tanhsinh")
 class TestFixedOrderRuleDTypes:
     """The fixed order rules are a public entry point in their own right."""
 
-    @pytest.mark.parametrize("rule", RULES)
+    @pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
     @pytest.mark.parametrize("dtype", real_dtypes)
     def test_integrate(self, rule, dtype):
         """All four outputs of ``integrate`` come back at the abscissa dtype."""
@@ -517,7 +627,7 @@ class TestFixedOrderRuleDTypes:
         tol = SLOP * np.sqrt(float(jnp.finfo(dtype).eps))
         np.testing.assert_allclose(float(y), 1 - np.exp(-1), atol=tol)
 
-    @pytest.mark.parametrize("rule", RULES)
+    @pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
     @pytest.mark.parametrize("dtype", real_dtypes)
     def test_degenerate_interval(self, rule, dtype):
         """``a == b`` takes the other branch of a ``cond``, which has to agree.
@@ -531,7 +641,7 @@ class TestFixedOrderRuleDTypes:
             assert v.dtype == dtype
             np.testing.assert_array_equal(np.asarray(v), 0.0)
 
-    @pytest.mark.parametrize("rule", RULES)
+    @pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
     @pytest.mark.parametrize("dtype", real_dtypes)
     def test_apply(self, rule, dtype):
         """The low level ``_apply`` keeps the dtype too."""
@@ -539,7 +649,7 @@ class TestFixedOrderRuleDTypes:
         y = rule()._apply(exp_neg, a, b, ())
         assert y.dtype == dtype
 
-    @pytest.mark.parametrize("rule", RULES)
+    @pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
     def test_weights_sum_to_two(self, rule):
         """Both the high and low order rules integrate 1 over [-1, 1] exactly."""
         r = rule()
@@ -579,7 +689,7 @@ BATCH_IDS = ["1", "4", "5", "n-1", "n", "n+7"]
 
 
 @pytest.mark.usefixtures("quiet_tanhsinh")
-@pytest.mark.parametrize("rule", RULES)
+@pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
 @pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=BATCH_IDS)
 class TestBatchSize:
     """Splitting the node evaluation into batches must not change the answer.
@@ -634,7 +744,7 @@ class TestBatchSize:
 
 
 @pytest.mark.usefixtures("quiet_tanhsinh")
-@pytest.mark.parametrize("rule", RULES)
+@pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
 @pytest.mark.parametrize("batch_size", [0, -1, 2.5], ids=["zero", "negative", "float"])
 def test_bad_batch_size_rejected(rule, batch_size):
     """A batch size that is not a positive integer is a mistake, not a default."""

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -19,9 +19,12 @@ from .problems import (
     TAGS,
     TOLS,
     problem_id,
+    quadcc_open,
 )
 
-METHODS = {m.__name__ for m in (quadgk, quadcc, quadts, romberg, rombergts)}
+METHODS = {
+    m.__name__ for m in (quadgk, quadcc, quadcc_open, quadts, romberg, rombergts)
+}
 
 
 @pytest.mark.parametrize("i", ALL, ids=problem_id)


### PR DESCRIPTION
- Adds an open variant of the Clenshaw-Curtis rule. ``ClenshawCurtisRule`` and
  ``quadcc`` take a new ``closed`` argument, defaulting to ``True``, which keeps the
  existing closed rule. With ``closed=False`` the rule uses the Fejer-2 nodes: the same
  ``cos(k*pi/order)`` family with the two endpoints dropped, ``order - 1`` points exact
  to degree ``order - 1``, and the same 2:1 nesting against an embedded ``order // 2``
  rule.
  - The open variant is much cheaper on infinite intervals whose integrand decays
  algebraically or for integrands that are singular at an endpoint.
  - The closed rule remains the default and is the cheaper of the two on smooth, peaked
    and oscillatory integrands, by up to about a factor of two in evaluations.
- ``ClenshawCurtisRule``, ``TanhSinhRule``, ``quadcc``, and ``quadts`` now raise an
  error on an order that would build a malformed rule, rather than silently changing
  the order.