### PR TITLE
Adjoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ v0.3.0
   - ``LeibnizAdjoint`` gives the derivative its own adaptive solve, so it gets its own
     error control rather than inheriting the subdivision chosen for the integral. Often
     several times faster for a gradient of a scalar-valued integral.
+  - That solve can be configured separately from the integral's, via
+    ``LeibnizAdjoint(options={...}, options_fwd={...}, options_rev={...})``.
+    ``options_fwd`` and ``options_rev`` configure one direction alone, taking precedence
+    over ``options``. This matters most for ``norm``, because the two directions measure
+    different vectors: forward mode integrates the tangent of the integrand, of the
+    integrand's own shape, while reverse mode integrates the cotangent of the arguments
+    being differentiated, whose layout is documented on ``LeibnizAdjoint``.
 - Added control over how many integrand evaluations are made in parallel.
   - ``quadgk``, ``quadcc`` and ``quadts`` take a new ``batch_size``, as do the rule
     classes ``GaussKronrodRule``, ``ClenshawCurtisRule`` and ``TanhSinhRule``. It bounds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changelog
 
 v0.3.0
 ------
+- Reworked how a routine reports why it stopped.
+  - `QuadratureInfo.status` is now a `quadax.STATUS` naming the termination condition,
+    where it was previously an integer bitmask. `STATUS.normal` means the requested
+    tolerances were reached; every other member prints as the message explaining the
+    difficulty. This is a breaking change: `int(info.status)` and the old
+    `quadax.STATUS` lookup table are both gone, replaced by comparing against members,
+    eg `info.status == quadax.STATUS.divergent`.
+  - All six quadrature routines take a new `throw` option, default False. With
+    `throw=True` a run that stops for any reason other than reaching the requested
+    tolerance raises, with the message its status carries; the default reports the
+    status on `info` and leaves it to the caller.
+  - A run meeting more than one condition now reports the most severe rather than a
+    bitmask of all of them, ordered by what a reader should do about it: spend more
+    budget, distrust the error estimate, distrust the answer. Where the conditions
+    combined before, the reported one is the actionable one.
 - Added convergence acceleration to the adaptive integrators. The sequence of running
   totals is accelerated using Wynn's epsilon algorithm, which can greatly reduce the
   work needed for integrands with algebraic singularities or on infinite intervals.

--- a/docs/_templates/enum.rst
+++ b/docs/_templates/enum.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,6 +141,31 @@ handed a tangent instead, which the two vectors being the same length by coincid
 would otherwise hide.
 
 
+Termination status
+------------------
+
+Every iterative routine returns an info object whose ``status`` says why it stopped.
+``STATUS.normal`` means the requested tolerances were reached; every other member
+names a difficulty and prints as the message explaining it::
+
+    y, info = quadgk(fun, interval, epsabs=1e-10)
+    if info.status != quadax.STATUS.normal:
+        print(info.status)
+
+Pass ``throw=True`` to have the routine raise that message itself rather than report
+it, for code that should not carry on with an unconverged answer::
+
+    y, info = quadgk(fun, interval, epsabs=1e-10, throw=True)
+
+
+.. autosummary::
+    :toctree: _api/
+    :recursive:
+    :template: enum.rst
+
+    STATUS -- Reason a quadrature terminated
+
+
 Integrating function from sampled values
 ----------------------------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,16 +89,56 @@ is relative to the quadrature around it, how hard its derivative is to integrate
 compared to the integrand, and how many parameters are involved. Time both on your own
 problem before caring much about the difference.
 
-Both take two options controlling the memory a derivative needs. ``checkpoint`` (off by
-default) recomputes each block of sub-intervals during the backward pass instead of
-storing it, and is where nearly all of the saving is for :class:`~quadax.DirectAdjoint`,
-whose backward pass replays the frozen subdivision. :class:`~quadax.LeibnizAdjoint`
-solves for the adjoint instead of replaying anything, so there both options touch only
-the fixed-mesh pass that supplies the derivative with respect to the interval, and
-``checkpoint`` does nothing at all unless the limits are being differentiated.
-``chunk_size`` sets how many sub-intervals of the frozen subdivision are evaluated at
-once, and multiplies with the ``batch_size`` of the routine itself: a gradient evaluates
-the integrand at up to ``chunk_size * batch_size`` points at a time.
+:class:`~quadax.DirectAdjoint` takes two options controlling the memory a derivative
+needs. ``checkpoint`` (off by default) recomputes each block of sub-intervals during the
+backward pass instead of storing it, rather than replaying the frozen subdivision.
+``chunk_size`` sets how many sub-intervals of that subdivision are evaluated at once,
+and multiplies with the ``batch_size`` of the routine itself: a gradient evaluates the
+integrand at up to ``chunk_size * batch_size`` points at a time.
+:class:`~quadax.LeibnizAdjoint` takes neither. It replays no subdivision, its backward
+pass being an error controlled solve, and the derivative with respect to the limits is
+a boundary term rather than a mesh evaluation.
+
+Options for the derivative solve
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:class:`~quadax.LeibnizAdjoint` runs a solve of its own, and it does not have to be the
+solve the integral got. Give it ``options`` to override what the routine was called
+with::
+
+    quadgk(fun, interval, args, epsabs=1e-6,
+           adjoint=LeibnizAdjoint(options={"epsabs": 1e-10, "max_ninter": 200}))
+
+The integral is then computed to 1e-6 and its derivative to 1e-10, each stopping when it
+has converged rather than sharing a budget. :class:`~quadax.DirectAdjoint` takes no
+options of this kind, having no solve of its own to configure.
+
+Which vector the norm measures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The two directions of the derivative do not integrate the same vector, which is what
+``options_fwd`` and ``options_rev`` are for. They take the same names as ``options`` and
+take precedence over it, for one direction alone.
+
+Forward mode integrates the tangent of the integrand, a vector of the integrand's own
+shape. Reverse mode integrates the cotangent of the arguments being differentiated,
+raveled into a single flat vector. Its length is the total number of differentiated
+parameter components, which has nothing to do with the integrand's shape, and its
+entries are parameters rather than components of the integral. They appear in the order
+the quadrature's own arguments do: the limits, ``args``, and whatever the integrand
+closes over. Each contributes ``size`` entries if it is being differentiated and none
+at all if it is not. Differentiating a two point ``interval`` and a length three
+``args[0]`` gives a vector of five with the limits first; differentiating ``args[0]``
+alone gives a vector of three::
+
+    weights = jnp.array([1.0, 10.0, 100.0])          # one per parameter
+    norm = lambda x: jnp.linalg.norm(x * weights, ord=2)
+    jax.grad(lambda c: quadgk(fun, interval, (c,),
+                              adjoint=LeibnizAdjoint(options_rev={"norm": norm}))[0])(c)
+
+Putting that norm in ``options_rev`` rather than ``options`` is what stops it from being
+handed a tangent instead, which the two vectors being the same length by coincidence
+would otherwise hide.
 
 
 Integrating function from sampled values

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,9 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath("."))
-sys.path.append(os.path.abspath("../"))
+# Ahead of site-packages, so a build documents the source tree it sits in rather than
+# an installed copy of quadax that happens to shadow it.
+sys.path.insert(0, os.path.abspath("../"))
 import quadax
 
 project = "quadax"
@@ -403,3 +405,42 @@ latex_documents = [
 ]
 
 latex_toplevel_sectioning = "chapter"
+
+
+# -- Enumeration members -----------------------------------------------------------
+# `quadax.STATUS` is an `equinox.Enumeration`, whose members the metaclass keeps out of
+# the class namespace and serves through `__getattr__`. Neither `dir` nor `vars` sees
+# them, so autodoc documents such a class as though it were empty. equinox builds a
+# listing of its own, but only for a class carrying no docstring, and writes it in the
+# markdown its own docs are built from, which does not survive being read as reST.
+# This generates the same listing from the same source, in reST.
+import textwrap  # noqa: E402
+
+import equinox  # noqa: E402
+
+
+def _enumeration_members(cls):
+    """Name and message of each member, in declaration order.
+
+    ``_name_to_item`` is equinox's own record of them, and the only way to enumerate
+    them.
+    """
+    return [(name, cls[item]) for name, item in cls._name_to_item.items()]
+
+
+def _document_enumeration_members(app, what, name, obj, options, lines):
+    """Append the members of an Enumeration to its class page."""
+    if what != "class" or not isinstance(obj, type):
+        return
+    if not issubclass(obj, equinox.Enumeration) or obj is equinox.Enumeration:
+        return
+    lines += ["", ".. rubric:: Members", ""]
+    for member, message in _enumeration_members(obj):
+        lines.append(f"``{member}``")
+        lines += textwrap.wrap(message, 84, initial_indent="   ", subsequent_indent="   ")
+        lines.append("")
+
+
+def setup(app):
+    """Register the quadax-specific autodoc handling."""
+    app.connect("autodoc-process-docstring", _document_enumeration_members)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,8 +111,18 @@ The two multiply: a gradient evaluates the integrand at up to ``chunk_size`` tim
 
 ``LeibnizAdjoint`` takes no ``chunk_size``, and no ``checkpoint`` either. It evaluates
 no frozen subdivision, its backward pass is an error-controlled solve, and the
-derivative with respect to the limits is a boundary term, so ``batch_size`` is the
-only knob that applies to it.
+derivative with respect to the limits is a boundary term, so ``batch_size`` is the only
+knob of the routine's that applies to it. What it does take is ``options``, which
+configure that solve separately from the integral's with its own tolerances, its own
+``max_ninter``, even its own local rule::
+
+    quadgk(fun, interval, args, epsabs=1e-6,
+           adjoint=LeibnizAdjoint(options={"epsabs": 1e-10, "max_ninter": 200}))
+
+``options_fwd`` and ``options_rev`` configure one direction alone. The norm is the one
+to be careful with: in reverse mode it measures the cotangent of the parameters rather
+than anything shaped like the integral. See the Adjoints section of the API
+documentation.
 
 
 

--- a/quadax/__init__.py
+++ b/quadax/__init__.py
@@ -1,6 +1,7 @@
 """quadax : numerical quadrature with JAX."""
 
 from . import _version
+from ._status import STATUS
 from .adaptive import adaptive_quadrature, quadcc, quadgk, quadts
 from .adjoint import AbstractAdjoint, DirectAdjoint, LeibnizAdjoint
 from .fixed_order import (
@@ -12,7 +13,6 @@ from .fixed_order import (
 )
 from .romberg import romberg, rombergts
 from .sampled import cumulative_simpson, cumulative_trapezoid, simpson, trapezoid
-from .utils import STATUS
 
 __all__ = [
     "adaptive_quadrature",

--- a/quadax/_status.py
+++ b/quadax/_status.py
@@ -1,0 +1,122 @@
+"""Why a quadrature stopped, and the message that explains it."""
+
+import equinox as eqx
+import jax
+
+
+class STATUS(eqx.Enumeration):
+    """Reason a quadrature terminated.
+
+    Members are declared from least to most severe, and a run that meets more than one
+    condition reports the most severe of them. The order is what a reader should do
+    about each.
+
+    The message is the member's value, and is what ``repr`` shows::
+
+        >>> y, info = quadgk(fun, [0, 1])
+        >>> print(info.status)
+        >>> print(STATUS[info.status])  # the message on its own
+
+    Indexing works on a batch of statuses too, which is how a ``vmap``-ed quadrature is
+    read back.
+    """
+
+    normal = (
+        "Normal convergence. The estimated error fell below the requested tolerance, "
+    )
+
+    max_ninter = (
+        "The subdivision used all max_ninter sub-intervals without reaching the "
+        "tolerance. The value returned is the total over the mesh it ended with, and "
+        "the reported error is that mesh's own estimate for it. Raising max_ninter "
+        "helps if the subdivision was still making progress; where the integrand has "
+        "a singularity or a jump at a known point, passing that point in `interval` "
+        "as a breakpoint is worth more, since the mesh no longer has to find it."
+    )
+
+    max_divisions = (
+        "The schedule used all divmax refinement levels without reaching the "
+        "tolerance. A Romberg mesh halves the whole interval uniformly and cannot "
+        "refine near a difficulty, so an integrand with a local feature is better "
+        "given to quadgk or quadcc."
+    )
+
+    no_converge = (
+        "The convergence acceleration stopped making progress: six extrapolations in "
+        "a row produced nothing better than the one already held, while claiming an "
+        "error far below what the subdivision reports. The best of them is returned, "
+        "with its error widened to cover how far the later ones moved away from it. "
+        "The running totals most likely have no asymptotic form for the extrapolation "
+        "to fit."
+    )
+
+    truncation = (
+        "The tanh-sinh map leaves more of the integral outside the range its abscissae "
+        "cover than the tolerance allows, so refining further cannot reach it. This is "
+        "a property of the map in finite precision rather than of the mesh, and more "
+        "levels would only spend evaluations arriving at the same answer. The reported "
+        "error includes an estimate of what the map omits and remains a bound on the "
+        "value returned; it is the tolerance that is out of reach. Using higher "
+        "precision may allow lower error."
+    )
+
+    bad_integrand = (
+        "Subdivision drove sub-intervals down to a width of order the floating point "
+        "spacing across the interval, where the abscissae within one can no longer be "
+        "told apart, so the mesh cannot localize the difficulty any further. This is "
+        "what a non-integrable singularity looks like, or a feature narrower than the "
+        "abscissae can resolve. Check that the integral exists, and that any "
+        "singularity or discontinuity sits at a limit or a breakpoint rather than in "
+        "the interior of a sub-interval."
+    )
+
+    roundoff = (
+        "The achievable accuracy is limited by roundoff. Subdivision has stopped "
+        "buying accuracy: the error estimate has reached the floor the arithmetic "
+        "imposes, or the total stopped moving while its error stayed where it was. The "
+        "tolerance asked for is below what the integrand can be summed to at this "
+        "precision. The reported error may be understated, being built from the same "
+        "arithmetic that has bottomed out. Try loosening tolerances, or use higher "
+        "precision."
+    )
+
+    divergent = (
+        "The integral is suspected to be divergent. The extrapolated value bears no "
+        "relation to the running total it was built from. A finite value may still be "
+        "returned, but do not use it without establishing that the integral converges."
+    )
+
+
+def _index(status: STATUS) -> jax.Array:
+    """The member's position in the declaration order, ie its severity.
+
+    ``Enumeration`` holds it as the item's single pytree leaf, which is the same value
+    its message lookup and ``where`` address it by. Nothing public exposes it, and the
+    ordering comparison below is the whole reason it is wanted.
+    """
+    (value,) = jax.tree.leaves(status)
+    return value
+
+
+def escalate(status: STATUS, flag: STATUS, cond) -> STATUS:
+    """Raise ``status`` to ``flag`` where ``cond`` holds and ``flag`` is more severe.
+
+    A quadrature can meet several termination conditions at once, and reports the worst
+    of them. Taking the more severe rather than the first one raised is what lets a
+    condition detected after the loop has ended -- divergence, which is only testable
+    against the finished result -- override one the loop itself recorded.
+
+    ``cond`` is a scalar boolean, and ``flag`` a member of :class:`STATUS`.
+    """
+    return STATUS.where(cond & (_index(flag) > _index(status)), flag, status)
+
+
+def withdraw(status: STATUS, flag: STATUS, cond) -> STATUS:
+    """Clear ``flag`` where ``cond`` holds, leaving any other status alone.
+
+    A flag describing how the answer was reached rather than the answer itself can stop
+    applying once the run has finished: the tolerance may be met in the end by a route
+    that stalled on the way. Only the flag named is cleared, so a more severe one raised
+    since still stands.
+    """
+    return STATUS.where(cond & (status == flag), STATUS.normal, status)

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -19,6 +19,7 @@ from equinox.internal import unvmap_any
 from jax.typing import ArrayLike
 
 from . import _acceleration
+from ._status import STATUS, escalate, withdraw
 from .adjoint import (
     AbstractAdjoint,
     DirectAdjoint,
@@ -47,13 +48,6 @@ from .utils import (
     tree_where,
 )
 
-NORMAL_EXIT = 0
-MAX_NINTER = 1
-ROUNDOFF = 2
-BAD_INTEGRAND = 3
-NO_CONVERGE = 4
-DIVERGENT = 5
-
 
 @eqx.filter_jit
 def quadgk(
@@ -69,6 +63,7 @@ def quadgk(
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = True,
     batch_size: int | None = None,
+    throw: bool = False,
 ):
     """Global adaptive quadrature using Gauss-Kronrod rule.
 
@@ -133,6 +128,11 @@ def quadgk(
         Values larger than the number of nodes are clipped to it. In a gradient the
         adjoint evaluates several sub-intervals together, so the width there is
         ``batch_size`` times the adjoint's own ``chunk_size``.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
 
     Returns
     -------
@@ -143,9 +143,10 @@ def quadgk(
 
         * err : (float) Estimate of the error in the approximation.
         * neval : (int) Total number of function evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -183,6 +184,7 @@ def quadgk(
         max_ninter,
         adjoint=adjoint,
         extrapolate=extrapolate,
+        throw=throw,
     )
     info = QuadratureInfo(
         info.err, info.neval * rule.nodes_per_call, info.status, info.info
@@ -205,6 +207,7 @@ def quadcc(
     extrapolate: bool = True,
     batch_size: int | None = None,
     closed: bool = True,
+    throw: bool = False,
 ):
     """Global adaptive quadrature using Clenshaw-Curtis rule.
 
@@ -276,6 +279,11 @@ def quadcc(
         is what to use for integrands that are singular or undefined there; it is
         markedly cheaper on infinite intervals whose integrand decays algebraically,
         and on endpoint singularities. See ``ClenshawCurtisRule``.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
 
     Returns
     -------
@@ -286,9 +294,10 @@ def quadcc(
 
         * err : (float) Estimate of the error in the approximation.
         * neval : (int) Total number of function evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -326,6 +335,7 @@ def quadcc(
         max_ninter,
         adjoint=adjoint,
         extrapolate=extrapolate,
+        throw=throw,
     )
     info = QuadratureInfo(
         info.err, info.neval * rule.nodes_per_call, info.status, info.info
@@ -347,6 +357,7 @@ def quadts(
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = False,
     batch_size: int | None = None,
+    throw: bool = False,
 ):
     """Global adaptive quadrature using trapezoidal tanh-sinh rule.
 
@@ -411,6 +422,11 @@ def quadts(
         Values larger than the number of nodes are clipped to it. In a gradient the
         adjoint evaluates several sub-intervals together, so the width there is
         ``batch_size`` times the adjoint's own ``chunk_size``.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
 
     Returns
     -------
@@ -421,9 +437,10 @@ def quadts(
 
         * err : (float) Estimate of the error in the approximation.
         * neval : (int) Total number of function evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -461,6 +478,7 @@ def quadts(
         max_ninter,
         adjoint=adjoint,
         extrapolate=extrapolate,
+        throw=throw,
     )
     info = QuadratureInfo(
         info.err, info.neval * rule.nodes_per_call, info.status, info.info
@@ -480,6 +498,7 @@ def adaptive_quadrature(
     max_ninter: int = 50,
     adjoint: AbstractAdjoint = DirectAdjoint(),
     extrapolate: bool = True,
+    throw: bool = False,
     **kwargs,
 ):
     """Global adaptive quadrature.
@@ -530,6 +549,11 @@ def adaptive_quadrature(
         derivative), and is faster when the integrand is expensive or ``max_ninter``
         is generous; see the Adjoints section of the API documentation for when that
         is worth paying for.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
     kwargs : dict
         Additional keyword arguments passed to ``rule``.
 
@@ -542,9 +566,10 @@ def adaptive_quadrature(
 
         * err : (float) Estimate of the error in the approximation.
         * neval : (int) Total number of rule evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -615,6 +640,8 @@ def adaptive_quadrature(
     status = state["status"]
     info = state if full_output else None
     out = QuadratureInfo(err, neval, status, info)
+    if throw:
+        y = status.error_if(y, status != STATUS.normal)
     return y, out
 
 
@@ -671,7 +698,7 @@ def _accelerate(
     # `proceed` says this iteration still has something to record. A run that reached
     # the tolerance or raised a flag is over and reports the state it finished with, so
     # every update below is gated on it.
-    proceed = ~converged & (state["status"] == 0)
+    proceed = ~converged & (state["status"] == STATUS.normal)
     # Depth of the two halves the bisection just created. Both were recorded before this
     # is called, so slot `i` carries it.
     levcur = state["level"][i]
@@ -799,7 +826,7 @@ def _accelerate_full(
     # flag: in both cases the run is over and the mesh result is the one that will be
     # reported. It is skipped for good once `no_accel` is set, which abandons the
     # acceleration and lets the run finish as an ordinary subdivision.
-    proceed = ~converged & (state["status"] == 0)
+    proceed = ~converged & (state["status"] == STATUS.normal)
     active = proceed & ~state["no_accel"]
 
     # The error still sitting in sub-intervals that are not yet localized, ie those the
@@ -968,7 +995,7 @@ def _accelerate_full(
     }
     for key, value in updates.items():
         state[key] = tree_where(proceed, value, state[key])
-    state["status"] += 2**NO_CONVERGE * stalled
+    state["status"] = escalate(state["status"], STATUS.no_converge, stalled)
     return state
 
 
@@ -1000,7 +1027,7 @@ def _accept_extrapolation(state, mesh_y, norm):
         state["accel_err"],
     )
     # Whether anything was flagged at all, by the subdivision or by the table.
-    flagged = (state["status"] != 0) | state["roundoff_in_table"]
+    flagged = (state["status"] != STATUS.normal) | state["roundoff_in_table"]
 
     scale_accel = norm(accel_y)
     scale_mesh = norm(mesh_y)
@@ -1036,10 +1063,12 @@ def _accept_extrapolation(state, mesh_y, norm):
     divergent = have_accel & ~use_mesh & ~untestable & testable & diverging
 
     # Roundoff detected inside the table, where the subdivision itself reported nothing.
-    state["status"] += (
-        2**ROUNDOFF * have_accel * flagged * (state["status"] == 0) * ~use_mesh
+    state["status"] = escalate(
+        state["status"],
+        STATUS.roundoff,
+        have_accel & flagged & (state["status"] == STATUS.normal) & ~use_mesh,
     )
-    state["status"] += 2**DIVERGENT * divergent
+    state["status"] = escalate(state["status"], STATUS.divergent, divergent)
     state["used_accel"] = have_accel & ~use_mesh
     state["err_sum"] = jnp.where(use_mesh, mesh_err, accel_err)
     # QUADPACK never clears a flag once raised, which costs it nothing because its
@@ -1052,8 +1081,7 @@ def _accept_extrapolation(state, mesh_y, norm):
     # then the request was met, whichever of the two supplied it. Only this flag is
     # cleared, since the others describe the returned value and stand on their own.
     reached = state["err_sum"] <= state["err_bnd"]
-    stall_bit = (state["status"] & 2**NO_CONVERGE) != 0
-    state["status"] -= jnp.where(reached & stall_bit, 2**NO_CONVERGE, 0)
+    state["status"] = withdraw(state["status"], STATUS.no_converge, reached)
     return state, jnp.where(use_mesh, mesh_y, accel_y)
 
 
@@ -1086,7 +1114,7 @@ def _init_state(interval, shape, xtype, ytype, etype, max_ninter, extrapolate):
     state["b_arr"] = state["b_arr"].at[: state["ninter"]].set(interval[1:])
     state["roundoff1"] = 0  # for keeping track of roundoff errors
     state["roundoff2"] = 0  # for keeping track of roundoff errors
-    state["status"] = 0  # error flag
+    state["status"] = STATUS.normal  # why the run stopped
     # Explicitly typed rather than left as weak python floats: these are `scan` carries,
     # so their dtype has to match what the loop body writes back into them.
     state["err_bnd"] = jnp.zeros((), etype)  # error bound we're trying to reach
@@ -1255,10 +1283,14 @@ def _adaptive_solve(
 
     state["err_bnd"] = jnp.maximum(epsabs, epsrel * _norm(state["area"]))
     # check for roundoff error - error too big but relative error is small
-    state["status"] += 2**ROUNDOFF * _at_roundoff_floor(state, epmach, _norm)
+    state["status"] = escalate(
+        state["status"], STATUS.roundoff, _at_roundoff_floor(state, epmach, _norm)
+    )
 
     # check for max intervals exceeded
-    state["status"] += 2**MAX_NINTER * (state["ninter"] >= max_ninter)
+    state["status"] = escalate(
+        state["status"], STATUS.max_ninter, state["ninter"] >= max_ninter
+    )
 
     if extrapolate:
         # Give the saturated sub-intervals the whole error estimate, which puts them at
@@ -1291,7 +1323,7 @@ def _adaptive_solve(
 
     def condfun(state):
         keep_going = (
-            (state["status"] == 0)
+            (state["status"] == STATUS.normal)
             & (0 <= state["err_sum"])
             & (state["err_bnd"] <= state["err_sum"])
         )
@@ -1433,29 +1465,35 @@ def _adaptive_solve(
         # Roundoff is reported either because the error has bottomed out at the floor
         # the arithmetic imposes, or because the two counters say subdivision has
         # stopped buying anything.
-        state["status"] += (
-            2**ROUNDOFF
-            * ~converged
-            * (
+        state["status"] = escalate(
+            state["status"],
+            STATUS.roundoff,
+            ~converged
+            & (
                 _at_roundoff_floor(state, epmach, _norm)
                 | (state["roundoff1"] >= 10)
                 | (state["roundoff2"] >= 20)
-            )
+            ),
         )
 
         # test for max number of intervals
-        state["status"] += 2**MAX_NINTER * ~converged * (state["ninter"] >= max_ninter)
+        state["status"] = escalate(
+            state["status"],
+            STATUS.max_ninter,
+            ~converged & (state["ninter"] >= max_ninter),
+        )
 
         # test for bad behavior of the integrand (ie, intervals are getting too small)
         # This one is about the *mesh*, not the values, so it scales with the precision
         # the abscissae are carried at rather than the precision of the sums.
-        state["status"] += (
-            2**BAD_INTEGRAND
-            * ~converged
-            * (
+        state["status"] = escalate(
+            state["status"],
+            STATUS.bad_integrand,
+            ~converged
+            & (
                 jnp.maximum(jnp.abs(b1 - a1), jnp.abs(b2 - a2))
                 <= (100.0 * epmach_x * halfspan)
-            )
+            ),
         )
 
         # update the arrays of interval starts/ends etc

--- a/quadax/adaptive.py
+++ b/quadax/adaptive.py
@@ -588,9 +588,17 @@ def adaptive_quadrature(
 
     f_conv, consts = closure_convert(fun, args, dtypes.xtype)
 
+    # The options an adjoint may run its own solve with.
+    opts = {
+        "rule": rule,
+        "epsabs": epsabs,
+        "epsrel": epsrel,
+        "max_ninter": max_ninter,
+        "extrapolate": extrapolate,
+    }
     ops = QuadratureOps(
         build=partial(build_integrand, f_conv=f_conv),
-        solve=partial(_adaptive_solve, max_ninter=max_ninter, extrapolate=extrapolate),
+        solve=_adaptive_solve,
         rebuild=_rebuild_mesh,
         on_mesh=_quad_on_mesh,
         # An accelerated solve may return an extrapolated value rather than the sum over
@@ -600,9 +608,7 @@ def adaptive_quadrature(
         frozen_solve=_replay_solve if extrapolate else _mesh_solve,
         mesh_is_primal=not extrapolate,
     )
-    y, state = adjoint.quadrature(
-        ops, rule, interval, args, consts, epsabs, epsrel, kwargs
-    )
+    y, state = adjoint.quadrature(ops, interval, args, consts, kwargs, opts)
 
     err = state["err_sum"]
     neval = state["neval"]
@@ -1162,7 +1168,16 @@ def _init_state(interval, shape, xtype, ytype, etype, max_ninter, extrapolate):
 
 
 def _adaptive_solve(
-    rule, vfunc, interval, epsabs, epsrel, kwargs, *, max_ninter, extrapolate=False
+    vfunc,
+    interval,
+    kwargs,
+    *,
+    rule,
+    epsabs,
+    epsrel,
+    max_ninter,
+    extrapolate=False,
+    norm=None,
 ):
     """Run the globally adaptive subdivision loop.
 
@@ -1178,7 +1193,13 @@ def _adaptive_solve(
     a term each time it does. See ``_acceleration`` for the table itself,
     ``_accelerate_full`` for the control flow that decides all this, and
     ``_accept_extrapolation`` for the choice between the two answers at the end.
+
+    ``norm`` replaces the one the rule was built with, for a caller that measures a
+    vector other than the integrand's output. ``None``, the primal's case, keeps the
+    rule's own.
     """
+    if norm is not None:
+        rule = rule._with_norm(norm)
     intfun = partial(rule.integrate, **kwargs) if kwargs else rule.integrate
     _norm = rule.norm
     f = jax.eval_shape(vfunc, (interval[0] + interval[-1]) / 2)

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -919,13 +919,41 @@ def _tangent_integrand(dyn, dyn_t, *, ops, static):
     return dvfunc
 
 
-def _without_interval(tree):
-    """Zero out the limits' component of a tangent or cotangent, keeping the rest.
+def _live_leaves(dyn, tangents):
+    """Which of ``dyn``'s leaves are being differentiated, in flattened order.
 
-    The limits sit at position 1 of the primal tuple. Zeroing rather than dropping keeps
-    the pytree structure the solve and ``ravel_pytree`` expect.
+    ``eqx.filter_custom_jvp`` hands us a ``None`` tangent for every leaf that is not
+    differentiated, and a non-``None`` tangent for every leaf that is. Reverse mode
+    integrates the cotangent of the live leaves alone: the rest are asked for by nobody,
+    and integrating them is both wasteful and potentially harmful, since the error
+    control couples every component of the vector it measures through ``norm``.
     """
-    return (tree[0], jax.tree.map(jnp.zeros_like, tree[1]), *tree[2:])
+    is_none = lambda x: x is None
+    dyn_leaves = jax.tree.flatten(dyn, is_leaf=is_none)[0]
+    tan_leaves = jax.tree.flatten(tangents, is_leaf=is_none)[0]
+    return tuple(t is not None for d, t in zip(dyn_leaves, tan_leaves) if d is not None)
+
+
+def _keep_live(tree, live, treedef):
+    """Drop the leaves that are not being differentiated, keeping the tree's shape.
+
+    The dropped leaves become ``None``, which is an empty pytree node rather than a
+    leaf, so ``ravel_pytree`` skips them and the vector the solve carries holds the live
+    components alone. Unravelling puts the ``None`` back, which is what tells the
+    transpose rule to report a symbolic zero cotangent there.
+    """
+    leaves = jax.tree.flatten(tree)[0]
+    return jax.tree.unflatten(treedef, [x if k else None for x, k in zip(leaves, live)])
+
+
+def _add_live(tree, other):
+    """Add ``other`` into the live leaves of ``tree``, leaving dropped ones alone."""
+    is_none = lambda x: x is None
+    leaves, treedef = jax.tree.flatten(tree, is_leaf=is_none)
+    others = jax.tree.flatten(other, is_leaf=is_none)[0]
+    return jax.tree.unflatten(
+        treedef, [a if a is None else a + b for a, b in zip(leaves, others)]
+    )
 
 
 def _leibniz_impl(
@@ -937,10 +965,12 @@ def _leibniz_impl(
     kwargs_items,
     frozen_treedef,
     freeze,
+    live,
     interval_from_solve,
     out_sds,
 ):
     """Forward direction: integrate the tangent of the mapped integrand."""
+    del live  # only used on backward pass
     dyn_t, dyn, primals, frozen = _leibniz_unpack(
         flat, n, treedef, static, frozen_treedef
     )
@@ -978,6 +1008,7 @@ def _leibniz_transpose(
     kwargs_items,
     frozen_treedef,
     freeze,
+    live,
     interval_from_solve,
     out_sds,
 ):
@@ -993,25 +1024,20 @@ def _leibniz_transpose(
     rule, interval, args, consts, epsabs, epsrel = primals
     kwargs = dict(kwargs_items)
     vfunc, interval_t = ops.build(interval, args, consts)
-    _, unravel = ravel_pytree(dyn)
+    # Only the arguments actually being differentiated reach the solve. Integrating the
+    # rest buys nothing, since nobody asked for them, and it costs: the error control is
+    # driven by `rule.norm` over the whole raveled vector, so a component that
+    # misbehaves sets the mesh for every component, and the limits are exactly such a
+    # component: differentiating an integral whose integrand is unbounded at a limit
+    # gives an unbounded adjoint integrand. Convergence acceleration couples them harder
+    # still, since the epsilon table's structural decisions are made on the norm as
+    # well.
+    _, unravel = ravel_pytree(_keep_live(dyn, live, treedef))
 
     def adjoint_integrand(t):
         at_t = partial(_integrand_at, t=t, ops=ops, static=static)
         _, vjp = jax.vjp(at_t, dyn)
-        ct_dyn = vjp(ct)[0]
-        if not interval_from_solve:
-            # Drop the limits' components before they reach the solve. Nobody asked for
-            # them, so integrating them buys nothing, and it costs, because they are the
-            # components that misbehave: differentiating an integral whose integrand is
-            # unbounded at a limit gives an unbounded adjoint integrand, and the error
-            # control is driven by `rule.norm` over the whole raveled vector, so one
-            # divergent component sets the mesh for every component. Convergence
-            # acceleration couples them harder still, since the epsilon table's
-            # structural decisions are made on the norm as well. Forward mode zeroes the
-            # tangent's limits the same way, see `_leibniz_impl`; without this the two
-            # modes are not solving the same problem.
-            ct_dyn = _without_interval(ct_dyn)
-        return ravel_pytree(ct_dyn)[0]
+        return ravel_pytree(_keep_live(vjp(ct)[0], live, treedef))[0]
 
     flat_ct = _run_solve(
         ops,
@@ -1028,8 +1054,12 @@ def _leibniz_transpose(
         # The adjoint integrand carries the limits' cotangent only through the
         # integrand, so the boundary term is added here, as in forward mode.
         term = _endpoint_term(vfunc, interval_t, ops=ops, static=static)
-        ct_tree = jax.tree.map(jnp.add, ct_tree, jax.vjp(term, dyn)[1](ct)[0])
-    ct_leaves = jax.tree.flatten(ct_tree)[0]
+        ct_tree = _add_live(ct_tree, jax.vjp(term, dyn)[1](ct)[0])
+    # One cotangent per linear operand, in the order they were bound: the solved ones
+    # in tree order, and `None` (the symbolic zero JAX expects for an operand that was
+    # not differentiated) for the leaves dropped above.
+    solved = iter(jax.tree.flatten(ct_tree)[0])
+    ct_leaves = [next(solved) if k else None for k in live]
     # cotangents for the linear operands, then None for every residual operand
     n_res = len(flat) - n
     return tuple(ct_leaves) + (None,) * n_res
@@ -1139,6 +1169,10 @@ def _leibniz_jvp(primals, tangents, *, ops, freeze=False):
     # is whenever they are being differentiated at all. `filter_custom_jvp` tells us at
     # trace time by handing us a `None` tangent for anything that is not.
     interval_from_solve = any(t is not None for t in jax.tree.leaves(tangents[1]))
+    # The same statement for every argument rather than for the limits alone: which
+    # cotangents the reverse solve has to carry, and so what the vector its `norm`
+    # measures is made of.
+    live = _live_leaves(dyn, tangents[:-1])
     if freeze:
         frozen_leaves, frozen_treedef = jax.tree.flatten(
             jax.lax.stop_gradient(ops.frozen(state))
@@ -1156,6 +1190,7 @@ def _leibniz_jvp(primals, tangents, *, ops, freeze=False):
         kwargs_items=tuple(sorted(kwargs.items())),
         frozen_treedef=frozen_treedef,
         freeze=freeze,
+        live=live,
         interval_from_solve=interval_from_solve,
         out_sds=jax.ShapeDtypeStruct(jnp.shape(y), jnp.result_type(y)),
     )

--- a/quadax/adjoint.py
+++ b/quadax/adjoint.py
@@ -16,7 +16,6 @@ from jax.flatten_util import ravel_pytree
 from jax.interpreters import ad, batching, mlir
 
 from . import _acceleration
-from .fixed_order import AbstractQuadratureRule
 from .utils import (
     _real_dtype,
     check_size,
@@ -83,8 +82,10 @@ class QuadratureOps(NamedTuple):
         ``safe`` asks for an inf/nan mask that survives reverse mode, which the
         adjoints request for the evaluations they differentiate.
     solve : callable
-        ``solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs) -> (y, state)``. Runs
-        the full (adaptive) quadrature.
+        ``solve(vfunc, interval_t, kwargs, **opts) -> (y, state)``. Runs the full
+        (adaptive) quadrature. Everything the solve is configured by, the local rule
+        and the tolerances included, arrives in ``opts`` rather than closed over, so
+        that an adjoint running a solve of its own can override it by merging.
     rebuild : callable or None
         ``rebuild(interval_t, state) -> (a_arr, b_arr)``. Rebuilds the subdivision from
         ``interval_t`` using the owner/fraction bookkeeping recorded in ``state``, so
@@ -117,6 +118,38 @@ class QuadratureOps(NamedTuple):
     frozen: Callable | None = None
     frozen_solve: Callable | None = None
     mesh_is_primal: bool = True
+
+
+def _items(opts):
+    """A solve's options in a form the derivative rule can carry them in.
+
+    They ride as operands so that an array valued option stays traced, which means
+    their static half ends up in a primitive parameter, and a parameter has to be
+    hashable. Sorted pairs are; a dict is not. Sorting compares keys alone, they being
+    unique, so a callable among the values never has to be ordered. ``kwargs`` crosses
+    the same boundary the same way, see the bind in ``_leibniz_jvp``.
+    """
+    return tuple(sorted(opts.items()))
+
+
+def _merge(opts, *overrides):
+    """``opts`` with ``overrides`` applied in turn, later ones winning.
+
+    An override of an array valued option is cast to the dtype the routine resolved for
+    that name, so that a tolerance handed in as a bare python float, or at a wider
+    precision than the integral is being worked at, cannot widen the working precision.
+    Names the routine does not have are passed through untouched, and rejected by the
+    solve itself when it is called.
+    """
+    merged = dict(opts)
+    for override in overrides:
+        merged.update(override)
+    return {
+        k: jnp.asarray(v, jnp.result_type(opts[k]))
+        if k in opts and eqx.is_inexact_array(opts[k])
+        else v
+        for k, v in merged.items()
+    }
 
 
 def _with_options(ops, checkpoint, chunk_size):
@@ -470,13 +503,11 @@ class AbstractAdjoint(eqx.Module):
     def quadrature(
         self,
         ops: QuadratureOps,
-        rule: AbstractQuadratureRule | None,
         interval: jax.Array,
         args: tuple,
         consts: tuple,
-        epsabs: jax.Array,
-        epsrel: jax.Array,
         kwargs: dict,
+        opts: dict,
     ) -> tuple[jax.Array, dict]:
         """Evaluate the quadrature and define how it is differentiated.
 
@@ -484,8 +515,6 @@ class AbstractAdjoint(eqx.Module):
         ----------
         ops : QuadratureOps
             Primitive operations for this quadrature method.
-        rule : AbstractQuadratureRule
-            Local quadrature rule. Ignored by methods that do not use one.
         interval : jax.Array
             Limits of integration with possible breakpoints, in the original
             (unmapped) coordinates.
@@ -494,10 +523,10 @@ class AbstractAdjoint(eqx.Module):
         consts : tuple
             Values closed over by the integrand, hoisted out by
             ``jax.closure_convert`` so that they are visible to AD.
-        epsabs, epsrel : jax.Array
-            Absolute and relative error tolerances.
         kwargs : dict
             Additional keyword arguments passed to ``rule``.
+        opts : dict
+            Options for ``ops.solve``, including the local rule and the tolerances.
 
         Returns
         -------
@@ -517,10 +546,10 @@ class _UnrolledDirectAdjoint(AbstractAdjoint):
     loop, including iterations that did no work.
     """
 
-    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+    def quadrature(self, ops, interval, args, consts, kwargs, opts):
         """Evaluate the quadrature, differentiating straight through the loop."""
         vfunc, interval_t = ops.build(interval, args, consts, safe=True)
-        return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+        return ops.solve(vfunc, interval_t, kwargs, **opts)
 
 
 class DirectAdjoint(AbstractAdjoint):
@@ -624,33 +653,35 @@ class DirectAdjoint(AbstractAdjoint):
     def __post_init__(self):
         check_size(self.chunk_size, "chunk_size")
 
-    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+    def quadrature(self, ops, interval, args, consts, kwargs, opts):
         """Evaluate the quadrature and differentiate it on the converged subdivision."""
         ops = _with_options(ops, self.checkpoint, self.chunk_size)
         if ops.rebuild is None:
             if ops.frozen_solve is not None:
                 # No subdivision, but a discretization we can freeze (Romberg). Route
-                # through the primitive so that both modes work.
+                # through the primitive so that both modes work. The derivative is
+                # taken on that frozen discretization, so it runs no solve of its own
+                # and the same options serve all three slots.
                 return _leibniz(
-                    rule,
                     interval,
                     args,
                     consts,
-                    epsabs,
-                    epsrel,
+                    _items(opts),
+                    _items(opts),
+                    _items(opts),
                     kwargs,
                     ops=ops,
                     freeze=True,
                 )
             vfunc, interval_t = ops.build(interval, args, consts, safe=True)
-            return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
-        return _direct(rule, interval, args, consts, epsabs, epsrel, kwargs, ops=ops)
+            return ops.solve(vfunc, interval_t, kwargs, **opts)
+        return _direct(interval, args, consts, opts, kwargs, ops=ops)
 
 
 @eqx.filter_custom_jvp
-def _direct(rule, interval, args, consts, epsabs, epsrel, kwargs, *, ops):
+def _direct(interval, args, consts, opts, kwargs, *, ops):
     vfunc, interval_t = ops.build(interval, args, consts)
-    return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+    return ops.solve(vfunc, interval_t, kwargs, **opts)
 
 
 @_direct.def_jvp
@@ -667,10 +698,11 @@ def _direct_jvp(primals, tangents, *, ops):
     # When the limits are not being differentiated the converged subdivision can be used
     # as-is. filter_custom_jvp gives a `None` tangent for anything not being
     # differentiated, so this is known at trace time.
-    interval_perturbed = any(t is not None for t in jax.tree.leaves(tangents[1]))
+    interval_perturbed = any(t is not None for t in jax.tree.leaves(tangents[0]))
 
     def fixed_mesh(dyn_):
-        rule_, interval_, args_, consts_, _, _, kwargs_ = eqx.combine(dyn_, static)
+        interval_, args_, consts_, opts_, kwargs_ = eqx.combine(dyn_, static)
+        rule_ = opts_["rule"]
         vfunc, interval_t = ops.build(interval_, args_, consts_, safe=True)
         if not ops.mesh_is_primal:
             # Convergence acceleration may have returned an extrapolated value instead
@@ -732,11 +764,18 @@ def _leibniz_unpack(flat, n, treedef, static, frozen_treedef):
     return tangent, dyn, eqx.combine(dyn, static), frozen
 
 
-def _run_solve(ops, rule, integrand, interval_t, epsabs, epsrel, kwargs, frozen):
-    """Adaptive solve, or evaluation on a frozen discretization if there is one."""
+def _run_solve(ops, integrand, interval_t, kwargs, opts, frozen):
+    """Adaptive solve, or evaluation on a frozen discretization if there is one.
+
+    ``opts`` is the one this direction of the derivative uses, which is the primal's
+    unless the adjoint was given options of its own. A frozen discretization is not
+    error controlled, so it takes none of them beyond the rule to evaluate with, which
+    is absent for a quadrature that has no local rule.
+    """
+    opts = dict(opts)
     if frozen is None:
-        return ops.solve(rule, integrand, interval_t, epsabs, epsrel, kwargs)[0]
-    return ops.frozen_solve(rule, integrand, interval_t, frozen, kwargs)
+        return ops.solve(integrand, interval_t, kwargs, **opts)[0]
+    return ops.frozen_solve(opts.get("rule"), integrand, interval_t, frozen, kwargs)
 
 
 # The ratio between successive probe offsets used to read a breakpoint's one-sided
@@ -886,7 +925,7 @@ def _endpoint_term(vfunc, interval_t, *, ops, static):
     jumps = _breakpoint_jumps(vfunc, interval_t)
 
     def term(dyn_):
-        _, interval, args, consts, _, _ = eqx.combine(dyn_, static)
+        interval, args, consts, _, _, _ = eqx.combine(dyn_, static)
         _, limits = ops.build(interval, args, consts)
         out = hi * limits[-1] - lo * limits[0]
         if jumps is not None:
@@ -904,7 +943,7 @@ def _integrand_at(dyn_, *, t, ops, static):
     differentiate this: forward mode pushes a tangent through it, reverse mode pulls a
     cotangent back.
     """
-    _, interval, args, consts, _, _ = eqx.combine(dyn_, static)
+    interval, args, consts, _, _, _ = eqx.combine(dyn_, static)
     vf, _ = ops.build(interval, args, consts, safe=True)
     return vf(t)
 
@@ -974,19 +1013,17 @@ def _leibniz_impl(
     dyn_t, dyn, primals, frozen = _leibniz_unpack(
         flat, n, treedef, static, frozen_treedef
     )
-    rule, interval, args, consts, epsabs, epsrel = primals
+    interval, args, consts, _, opts_fwd, _ = primals
     kwargs = dict(kwargs_items)
     vfunc, interval_t = ops.build(interval, args, consts)
 
     del out_sds
     y_dot = _run_solve(
         ops,
-        rule,
         _tangent_integrand(dyn, dyn_t, ops=ops, static=static),
         interval_t,
-        epsabs,
-        epsrel,
         kwargs,
+        opts_fwd,
         frozen if freeze else None,
     )
     if interval_from_solve:
@@ -1021,7 +1058,7 @@ def _leibniz_transpose(
         # fed to `jax.vjp` below, which requires an array and rejects the symbolic form.
         return (None,) * len(flat)
     _, dyn, primals, frozen = _leibniz_unpack(flat, n, treedef, static, frozen_treedef)
-    rule, interval, args, consts, epsabs, epsrel = primals
+    interval, args, consts, _, _, opts_rev = primals
     kwargs = dict(kwargs_items)
     vfunc, interval_t = ops.build(interval, args, consts)
     # Only the arguments actually being differentiated reach the solve. Integrating the
@@ -1041,12 +1078,10 @@ def _leibniz_transpose(
 
     flat_ct = _run_solve(
         ops,
-        rule,
         adjoint_integrand,
         interval_t,
-        epsabs,
-        epsrel,
         kwargs,
+        opts_rev,
         frozen if freeze else None,
     )
     ct_tree = unravel(flat_ct)
@@ -1090,8 +1125,37 @@ class LeibnizAdjoint(AbstractAdjoint):
     Because each mode picks its own subdivision, forward and reverse results agree to
     quadrature accuracy rather than exactly.
 
+    Parameters
+    ----------
+    options : dict, optional
+        Options for the derivative's own solve, replacing the ones the quadrature
+        routine was called with. Default is to solve for the derivative with the same
+        options as the integral.
+    options_fwd, options_rev : dict, optional
+        The same, for one direction alone, taking precedence over ``options``. Which
+        vector is being measured differs between the two directions, so ``norm`` is the
+        option most likely to want this; see the note below.
+
     Notes
     -----
+    The two directions of the derivative do not integrate the same vector, which is
+    what ``options_fwd`` and ``options_rev`` are for.
+
+    Forward mode integrates the tangent of the integrand, a vector of the integrand's
+    own shape. Reverse mode integrates the cotangent of the arguments being
+    differentiated, raveled into a single flat vector. Its length is the total number
+    of differentiated parameter components, which has nothing to do with the
+    integrand's shape, and its entries are parameters rather than components of the
+    integral. They appear in the order the quadrature's own arguments do: the limits,
+    ``args``, and whatever the integrand closes over. Each contributing ``size`` entries
+    if it is being differentiated and none at all if it is not. Differentiating a two
+    point ``interval`` and a length three ``args[0]`` gives a vector of five with the
+    limits first; differentiating ``args[0]`` alone gives a vector of three.
+
+    A ``norm`` weighted per parameter is written against that layout, and belongs in
+    ``options_rev`` so that it is never handed a tangent instead, which the two vectors
+    being the same length by coincidence would otherwise hide.
+
     When differentiating a moving jump or singularity, mark the jump or singularity
     with a breakpoint, and build that breakpoint from the same parameter that positions
     the feature. Marking a feature that is genuinely there is never worse than leaving
@@ -1138,20 +1202,32 @@ class LeibnizAdjoint(AbstractAdjoint):
     to the derivative since the integrand has the same limit from both sides of it.
     """
 
-    def quadrature(self, ops, rule, interval, args, consts, epsabs, epsrel, kwargs):
+    options: dict = eqx.field(default_factory=dict)
+    options_fwd: dict = eqx.field(default_factory=dict)
+    options_rev: dict = eqx.field(default_factory=dict)
+
+    def quadrature(self, ops, interval, args, consts, kwargs, opts):
         """Evaluate the quadrature, differentiating it by the Leibniz rule."""
         return _leibniz(
-            rule, interval, args, consts, epsabs, epsrel, kwargs, ops=ops, freeze=False
+            interval,
+            args,
+            consts,
+            _items(opts),
+            _items(_merge(opts, self.options, self.options_fwd)),
+            _items(_merge(opts, self.options, self.options_rev)),
+            kwargs,
+            ops=ops,
+            freeze=False,
         )
 
 
 @eqx.filter_custom_jvp
 def _leibniz(
-    rule, interval, args, consts, epsabs, epsrel, kwargs, *, ops, freeze=False
+    interval, args, consts, opts, opts_fwd, opts_rev, kwargs, *, ops, freeze=False
 ):
-    del freeze
+    del freeze, opts_fwd, opts_rev
     vfunc, interval_t = ops.build(interval, args, consts)
-    return ops.solve(rule, vfunc, interval_t, epsabs, epsrel, kwargs)
+    return ops.solve(vfunc, interval_t, kwargs, **dict(opts))
 
 
 @_leibniz.def_jvp
@@ -1168,7 +1244,7 @@ def _leibniz_jvp(primals, tangents, *, ops, freeze=False):
     # Whether the solve is the thing that has to produce the limits' cotangent, which it
     # is whenever they are being differentiated at all. `filter_custom_jvp` tells us at
     # trace time by handing us a `None` tangent for anything that is not.
-    interval_from_solve = any(t is not None for t in jax.tree.leaves(tangents[1]))
+    interval_from_solve = any(t is not None for t in jax.tree.leaves(tangents[0]))
     # The same statement for every argument rather than for the limits alone: which
     # cotangents the reverse solve has to carry, and so what the vector its `norm`
     # measures is made of.

--- a/quadax/fixed_order.py
+++ b/quadax/fixed_order.py
@@ -14,7 +14,7 @@ from .quad_weights import (
     get_tanhsinh_table,
     gk_weights,
 )
-from .utils import _real_dtype, check_size, tanhsinh_tmax, wrap_func
+from .utils import _real_dtype, check_size, errorif, tanhsinh_tmax, wrap_func
 
 
 def _dot(w, f):
@@ -135,6 +135,25 @@ class AbstractQuadratureRule(eqx.Module):
     def norm(self, x: jax.Array) -> jax.Array:
         """Norm to use for measuring error for vector valued integrands."""
         return jnp.linalg.norm(jnp.asarray(x).flatten(), ord=jnp.inf)
+
+    def _with_norm(
+        self, norm: float | int | Callable[[jax.Array], jax.Array]
+    ) -> "AbstractQuadratureRule":
+        """A copy of this rule that measures vector valued error with ``norm``.
+
+        Internal: used by the adjoints, which may run an error controlled solve whose
+        vector is not the integrand's output, and so needs a norm of its own. Users
+        writing a custom rule only need this if they want that to work; the default
+        below is correct for any rule built from a norm, and a rule that measures error
+        some other way should override it or let it raise.
+        """
+        errorif(
+            not hasattr(self, "_norm"),
+            NotImplementedError,
+            f"{type(self).__name__} was not built from a norm, so it cannot be rebuilt "
+            "with a different one.",
+        )
+        return eqx.tree_at(lambda rule: rule._norm, self, norm)
 
 
 class NestedRule(AbstractQuadratureRule):

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.typing import ArrayLike
 
+from ._status import STATUS, escalate
 from .adjoint import (
     AbstractAdjoint,
     DirectAdjoint,
@@ -45,6 +46,7 @@ def romberg(
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
     divmin: int = 4,
+    throw: bool = False,
 ):
     """Romberg integration of a callable function or method.
 
@@ -123,6 +125,11 @@ def romberg(
         each, which is where the default schedule wastes time on GPU/TPU. What is paid
         is a floor of ``2**divmin + 1`` evaluations even on an integrand that needed
         fewer.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
 
     Returns
     -------
@@ -136,9 +143,10 @@ def romberg(
           last one alone, plus the tail that movement's own contraction rate implies,
           and floored at the precision the integrand can be summed to.
         * neval : (int) Total number of function evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -199,6 +207,7 @@ def romberg(
         extrapolate,
         batch_size,
         divmin,
+        throw,
     )
 
 
@@ -217,6 +226,7 @@ def _romberg(
     extrapolate,
     batch_size,
     divmin,
+    throw,
     truncation=None,
 ):
     """Shared driver for ``romberg`` and ``rombergts``.
@@ -261,7 +271,10 @@ def _romberg(
     )
     y, state = adjoint.quadrature(ops, interval, args, consts, {}, opts)
     info = state["table"] if full_output else None
-    out = QuadratureInfo(state["err_sum"], state["neval"], state["status"], info)
+    status = state["status"]
+    out = QuadratureInfo(state["err_sum"], state["neval"], status, info)
+    if throw:
+        y = status.error_if(y, status != STATUS.normal)
     return y, out
 
 
@@ -722,30 +735,69 @@ def _romberg_solve(
     if divmin < 1:
         err = jnp.array(jnp.inf, rtype)
 
-    state = (result, divmin + 1, neval, err, y, resabs, d, dprev, outer)
+    def flag(status, y, err, resabs, outer, nlevels):
+        """Which of the run's stopping conditions the state after ``nlevels`` meets.
+
+        The conditions are not exclusive, and the most severe of those that hold is the
+        one carried forward.
+        """
+        missed = unconverged(y, err, nlevels)
+        # There is no row `nlevels + 1` to compute, so this is the schedule's last word.
+        last = nlevels >= divmax
+        status = escalate(status, STATUS.max_divisions, missed & last)
+
+        # Neither floor below can be read off an estimate with too little history to
+        # mean anything: under `_MIN_LEVELS`, `missed` is reporting the levels still
+        # owed rather than a shortfall in the answer, and the estimate is small because
+        # nothing has moved yet, not because it has bottomed out.
+        rested = nlevels >= _MIN_LEVELS
+
+        tol = jnp.maximum(epsabs, epsrel * _norm(y))
+        # A zero tolerance is not a threshold that can be missed, it is a request to
+        # refine as far as `divmax` allows. Neither floor is read as unreachable then,
+        # since nothing was asked that the run could fall short of, and the schedule is
+        # left to spend its budget.
+        asked = tol > 0
+
+        trunc = trunc_of(outer)
+        # A floor the map itself holds above the tolerance, which no number of levels
+        # crosses.
+        above_floor = asked & (trunc > tol)
+        # Refining is only abandoned once the mesh's own share has fallen to that floor:
+        # every further level then doubles the evaluations while the reported error
+        # stays where it is. Since the two shares are added, `err <= 2 * trunc` is the
+        # mesh share having reached it. Until then the levels still buy accuracy, just
+        # never the tolerance, so the diagnosis waits unless there is nothing left to
+        # spend anyway.
+        settled = (err <= 2 * trunc) & rested
+        status = escalate(
+            status, STATUS.truncation, missed & above_floor & (settled | last)
+        )
+
+        # `_romberg_err` floors the estimate at the precision the integrand can be
+        # summed to, so a run sitting on that floor is asking for more than the
+        # arithmetic can deliver, however many levels remain.
+        floor = 50.0 * eps * _norm(resabs)
+        status = escalate(
+            status, STATUS.roundoff, missed & rested & asked & (err <= floor)
+        )
+        return status
+
+    # The starting sweep can already have met one of them, on a run whose loop never
+    # executes because `divmin` reaches `divmax`.
+    status = flag(STATUS.normal, y, err, resabs, outer, divmin)
+    state = (result, divmin + 1, neval, err, y, resabs, d, dprev, outer, status)
 
     def ncond(state):
-        result, n, neval, err, y, resabs, dprev, dprev2, outer = state
+        result, n, neval, err, y, resabs, dprev, dprev2, outer, status = state
         # `n` is the row about to be computed, so `n - 1` rows are complete and `y` is
-        # the value read off the last of them.
-        tol = jnp.maximum(epsabs, epsrel * _norm(y))
-        trunc = trunc_of(outer)
-        # Refining is pointless once the mesh has converged onto a floor the map itself
-        # holds above the tolerance: every further level doubles the evaluations while
-        # the reported error stays where it is. Since the two shares are added,
-        # `err <= 2 * trunc` is the mesh's own share having fallen to that floor. The
-        # run still ends unconverged, which is the honest outcome; this only declines to
-        # spend the rest of `divmax` reaching it.
-        # A zero tolerance is not a threshold that can be missed, it is a request to
-        # refine as far as `divmax` allows, so it is never read as unreachable.
-        hopeless = (
-            (tol > 0) & (trunc > tol) & (err <= 2 * trunc) & (n - 1 >= _MIN_LEVELS)
-        )
-        return (n < divmax + 1) & unconverged(y, err, n - 1) & ~hopeless
+        # the value read off the last of them. Reaching the tolerance is its own exit,
+        # since that leaves no flag to stop on.
+        return (n < divmax + 1) & unconverged(y, err, n - 1) & (status == STATUS.normal)
 
     def nloop(state):
         # loop over outer number of subdivisions
-        result, n, neval, err, yprev, resabs, dprev, dprev2, outer = state
+        result, n, neval, err, yprev, resabs, dprev, dprev2, outer, status = state
         h = (b - a) / 2**n
         s, sabs, ends, nbatch = _level_sum(
             vfunc, a, h, 2 ** (n - 1), batch_size, f.shape, f.dtype
@@ -758,13 +810,12 @@ def _romberg_solve(
         neval += nbatch * batch_size
         result, y, d = advance(result, n, yprev)
         err = total_err(d, dprev, dprev2, resabs, outer)
-        return result, n + 1, neval, err, y, resabs, d, dprev, outer
+        status = flag(status, y, err, resabs, outer, n)
+        return result, n + 1, neval, err, y, resabs, d, dprev, outer, status
 
-    result, n, neval, err, y, resabs, dprev, dprev2, outer = bounded_while_loop(
+    result, n, neval, err, y, resabs, dprev, dprev2, outer, status = bounded_while_loop(
         ncond, nloop, state, max(divmax - divmin, 0) + 1
     )
-
-    status = 2 * unconverged(y, err, n - 1)
     state = {
         "table": result,
         "err_sum": err,
@@ -829,6 +880,7 @@ def rombergts(
     adjoint: AbstractAdjoint = DirectAdjoint(),
     batch_size: int | None = None,
     divmin: int = 4,
+    throw: bool = False,
 ):
     """Romberg integration with tanh-sinh (aka double exponential) transformation.
 
@@ -907,6 +959,11 @@ def rombergts(
         each, which is where the default schedule wastes time on GPU/TPU. What is paid
         is a floor of ``2**divmin + 1`` evaluations even on an integrand that needed
         fewer.
+    throw : bool, optional
+        Whether to raise an error if the routine does not converge. If True, a run
+        that terminates for any reason other than reaching the requested tolerance
+        raises with the message its ``status`` carries. If False, the default, that
+        status is reported on the returned ``info`` and left to the caller to act on.
 
     Returns
     -------
@@ -920,9 +977,10 @@ def rombergts(
           last one alone, plus the tail that movement's own contraction rate implies,
           and floored at the precision the integrand can be summed to.
         * neval : (int) Total number of function evaluations.
-        * status : (int) Flag indicating reason for termination. status of 0 means
-          normal termination, any other value indicates a possible error. A human
-          readable message can be obtained by ``print(quadax.STATUS[status])``
+        * status : (quadax.STATUS) Why the routine terminated. ``STATUS.normal`` means
+          the requested tolerances were reached; every other member names a difficulty
+          and prints as the message explaining it. Where a run meets more than one
+          condition the most severe is reported.
         * info : (dict or None) Other information returned by the algorithm.
           Only present if ``full_output`` is True. Contains the following:
 
@@ -978,5 +1036,6 @@ def rombergts(
         extrapolate,
         batch_size,
         divmin,
+        throw,
         truncation=_tanhsinh_truncation,
     )

--- a/quadax/romberg.py
+++ b/quadax/romberg.py
@@ -182,18 +182,7 @@ def romberg(
         ValueError,
         f"divmax must be a non-negative integer, got {divmax}",
     )
-    errorif(
-        divmin > divmax,
-        ValueError,
-        f"divmin must not exceed divmax, got divmin={divmin}, divmax={divmax}",
-    )
-    # The starting sweep places `2**divmin - 1` interior points and no later level
-    # places more than `2**(divmax - 1)`, so a larger batch would only ever be padding.
-    batch_size = min(batch_size or 2**divmin, max(2**divmin, 2 ** max(divmax - 1, 0)))
-    if callable(norm):
-        _norm: Callable[[jax.Array], jax.Array] = norm
-    else:
-        _norm: Callable[[jax.Array], jax.Array] = partial(_pnorm, p=norm)
+    batch_size = _validate_levels(divmin, divmax, batch_size)
 
     return _romberg(
         fun,
@@ -203,7 +192,7 @@ def romberg(
         epsabs,
         epsrel,
         divmax,
-        _norm,
+        norm,
         adjoint,
         build_integrand,
         dtypes.xtype,
@@ -221,7 +210,7 @@ def _romberg(
     epsabs,
     epsrel,
     divmax,
-    _norm,
+    norm,
     adjoint,
     build,
     xtype,
@@ -240,19 +229,21 @@ def _romberg(
     # once a transformed integrand crosses a filter_jit boundary its leaves become
     # tracers that closure_convert cannot hoist.
     f_conv, consts = closure_convert(fun, args, xtype)
+    # The options an adjoint may run its own solve with.
+    opts = {
+        "epsabs": epsabs,
+        "epsrel": epsrel,
+        "divmax": divmax,
+        "divmin": divmin,
+        "norm": norm,
+        "extrapolate": extrapolate,
+        "batch_size": batch_size,
+    }
     # Romberg has no subdivision to reuse, so `rebuild`/`on_mesh` are left unset and
     # DirectAdjoint falls back to differentiating through the loop.
     ops = QuadratureOps(
         build=partial(build, f_conv=f_conv),
-        solve=partial(
-            _romberg_solve,
-            divmax=divmax,
-            _norm=_norm,
-            extrapolate=extrapolate,
-            batch_size=batch_size,
-            divmin=divmin,
-            truncation=truncation,
-        ),
+        solve=partial(_romberg_solve, truncation=truncation),
         # Romberg has no subdivision to reuse, but it does settle on a number of
         # Richardson levels. Freezing that makes the result a fixed linear functional of
         # the integrand, which is what DirectAdjoint needs to differentiate in either
@@ -268,7 +259,7 @@ def _romberg(
             divmin=divmin,
         ),
     )
-    y, state = adjoint.quadrature(ops, None, interval, args, consts, epsabs, epsrel, {})
+    y, state = adjoint.quadrature(ops, interval, args, consts, {}, opts)
     info = state["table"] if full_output else None
     out = QuadratureInfo(state["err_sum"], state["neval"], state["status"], info)
     return y, out
@@ -600,16 +591,36 @@ def _tanhsinh_truncation(edges, outer, rtype, _norm):
     return _norm(term[0] + term[1])
 
 
+def _as_norm(norm: int | float | Callable) -> Callable[[jax.Array], jax.Array]:
+    """Resolve a ``norm`` argument, an order or a callable, to a callable."""
+    return norm if callable(norm) else partial(_pnorm, p=norm)
+
+
+def _validate_levels(divmin, divmax, batch_size):
+    """Validate a refinement schedule and size the largest useful batch for it.
+
+    The starting sweep places ``2**divmin - 1`` interior points and no later level
+    places more than ``2**(divmax - 1)``, so a larger batch would only ever be padding.
+    Clamping is idempotent, so the routines may apply it eagerly and the solve may
+    apply it again to a schedule an adjoint has since changed.
+    """
+    errorif(
+        divmin > divmax,
+        ValueError,
+        f"divmin must not exceed divmax, got divmin={divmin}, divmax={divmax}",
+    )
+    return min(batch_size or 2**divmin, max(2**divmin, 2 ** max(divmax - 1, 0)))
+
+
 def _romberg_solve(
-    rule,
     vfunc,
     interval,
-    epsabs,
-    epsrel,
     kwargs,
     *,
+    epsabs,
+    epsrel,
     divmax,
-    _norm,
+    norm,
     extrapolate=True,
     batch_size=1,
     divmin=4,
@@ -620,8 +631,13 @@ def _romberg_solve(
     Without it this is plain adaptive bisection of the trapezoidal rule (or of the
     tanh-sinh rule, for ``rombergts``): the same nodes and the same halving schedule,
     reading column 0 of the table rather than choosing among its extrapolations.
+
+    The schedule is reconciled here rather than taken on trust, because an adjoint may
+    have moved ``divmin`` or ``divmax`` without knowing what batch they imply.
     """
-    del rule, kwargs
+    del kwargs
+    batch_size = _validate_levels(divmin, divmax, batch_size)
+    _norm = _as_norm(norm)
     a, b = interval
     # Vectorize whatever we were handed The primal integrand arrives vectorized already,
     # but the adjoints solve against one they build per point (the tangent or the
@@ -945,18 +961,7 @@ def rombergts(
         ValueError,
         f"divmin must be a non-negative integer, got {divmin}",
     )
-    errorif(
-        divmin > divmax,
-        ValueError,
-        f"divmin must not exceed divmax, got divmin={divmin}, divmax={divmax}",
-    )
-    # The starting sweep places `2**divmin - 1` interior points and no later level
-    # places more than `2**(divmax - 1)`, so a larger batch would only ever be padding.
-    batch_size = min(batch_size or 2**divmin, max(2**divmin, 2 ** max(divmax - 1, 0)))
-    if callable(norm):
-        _norm: Callable[[jax.Array], jax.Array] = norm
-    else:
-        _norm: Callable[[jax.Array], jax.Array] = partial(_pnorm, p=norm)
+    batch_size = _validate_levels(divmin, divmax, batch_size)
 
     return _romberg(
         fun,
@@ -966,7 +971,7 @@ def rombergts(
         epsabs,
         epsrel,
         divmax,
-        _norm,
+        norm,
         adjoint,
         _build_tanhsinh,
         dtypes.xtype,

--- a/quadax/utils.py
+++ b/quadax/utils.py
@@ -12,6 +12,8 @@ import numpy as np
 from equinox.internal import unvmap_any
 from jax.typing import ArrayLike
 
+from ._status import STATUS
+
 
 def errorif(cond: bool | jax.Array, err: type[Exception] = ValueError, msg: str = ""):
     """Raise an error if condition is met.
@@ -530,57 +532,6 @@ class _TanhSinhTransformedFunction(eqx.Module):
         return self.sgn * w * self.fun(x, *args)
 
 
-messages = {
-    # NORMAL_EXIT
-    0: "Algorithm terminated normally, desired tolerances assumed reached",
-    # MAX_NINTER
-    1: (
-        "Maximum number of subdivisions allowed has been achieved. One can allow more "
-        + "subdivisions by increasing the value of max_ninter. However,if this yields "
-        + "no improvement it is advised to analyze the integrand in order to determine "
-        + "the integration difficulties. If the position of a local difficulty can be "
-        + "determined (e.g. singularity, discontinuity within the interval) one will "
-        + "probably gain from splitting up the interval at this point and calling the "
-        + "integrator on the sub-ranges. If possible, an appropriate special-purpose "
-        + "integrator should be used, which is designed for handling the type of "
-        + "difficulty involved."
-    ),
-    # ROUNDOFF
-    2: (
-        "The occurrence of roundoff error is detected, which prevents the requested "
-        + "tolerance from being achieved. The error may be under-estimated."
-    ),
-    # BAD_INTEGRAND
-    3: (
-        "Extremely bad integrand behavior occurs at some points of the integration "
-        + "interval."
-    ),
-    # NO_CONVERGE
-    4: (
-        "The algorithm does not converge. Roundoff error is detected in the "
-        + "extrapolation table. It is assumed that the requested tolerance cannot be "
-        + "achieved, and that the returned result is the best which can be obtained."
-    ),
-    # DIVERGENT
-    5: "The integral is probably divergent, or slowly convergent.",
-}
-
-
-def _decode_status(status):
-    if status == 0:
-        msg = messages[0]
-    else:
-        status = f"{status:06b}"[::-1]
-        msg = ""
-        for s, m in zip(status, messages.values()):
-            if int(s):
-                msg += m + "\n\n"
-    return msg
-
-
-STATUS = {i: _decode_status(i) for i in range(int(2**6))}
-
-
 def wrap_func(
     fun: Callable[..., jax.Array],
     args: tuple[Any, ...],
@@ -745,10 +696,11 @@ class QuadratureInfo(NamedTuple):
         Estimate of the error in the quadrature result.
     neval : int
         Number of evaluations of the integrand.
-    status : int
-        Flag indicating reason for termination. status of 0 means normal termination,
-        any other value indicates a possible error. A human readable message can be
-        obtained by ``print(quadax.STATUS[status])``
+    status : STATUS
+        Why the routine terminated. ``STATUS.normal`` means the requested tolerances
+        were reached; every other member names a difficulty, and prints as the message
+        explaining it. Where a run meets several conditions the most severe is
+        reported.
     info : dict or None
         Other information returned by the algorithm. See specific algorithm for
         details. Only present if ``full_output`` is True.
@@ -756,7 +708,7 @@ class QuadratureInfo(NamedTuple):
 
     err: float | jax.Array
     neval: int | jax.Array
-    status: int | jax.Array
+    status: STATUS
     info: Any
 
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -784,7 +784,7 @@ def assert_honest(y, info, prob, tol, model=QUADPACK_MODEL):
     true_err = float(np.max(np.abs(value - exact)))
     reported = float(np.max(np.asarray(info.err)))
 
-    if int(info.status) == 0:
+    if info.status == STATUS.normal:
         assert true_err <= model.slack * reported, (
             f"{prob['name']} at tol={tol:g}: reported {reported:.3e} "
             f"< true {true_err:.3e}"
@@ -807,8 +807,8 @@ def assert_converged(y, info, prob, tol):
     """
     exact = np.asarray(prob["val"])
     value = np.asarray(y)
-    assert int(info.status) == 0, (
-        f"{prob['name']} at tol={tol:g}: {STATUS[int(info.status)]}"
+    assert info.status == STATUS.normal, (
+        f"{prob['name']} at tol={tol:g}: {STATUS[info.status]}"
     )
     reported = float(np.max(np.asarray(info.err)))
     assert reported <= max(tol, tol * float(np.max(np.abs(value)))), (

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,10 +1,12 @@
 """Tests for adaptive quadrature routines."""
 
 import os
+import re
 import subprocess
 import sys
 import warnings
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -164,7 +166,8 @@ class TestAdaptive:
         # The tightest tolerance sits below the roundoff floor of the near-divergent
         # problems, where declining to converge is the right answer rather than a
         # failure, and the smooth-only sweep is there to show it does not regress.
-        if not (main and tol in CONVERGENT_TOLS) and int(info.status) != 0:
+        unflagged = info.status == quadax.STATUS.normal
+        if not (main and tol in CONVERGENT_TOLS) and not unflagged:
             pytest.skip("convergence is not required of this case")
         assert_converged(y, info, prob, tol)
 
@@ -211,8 +214,8 @@ class TestRuleOrders:
                 order=order,
                 extrapolate=accelerates(method),
             )
-            assert int(info.status) == 0, (
-                f"{prob['name']} at order {order}: {quadax.STATUS[int(info.status)]}"
+            assert info.status == quadax.STATUS.normal, (
+                f"{prob['name']} at order {order}: {quadax.STATUS[info.status]}"
             )
             assert_honest(y, info, prob, self.TOL)
             assert_converged(y, info, prob, self.TOL)
@@ -240,8 +243,8 @@ class TestRuleOrders:
                 order=order,
                 full_output=True,
             )
-            assert int(info.status) == 0, (
-                f"{prob['name']} at order {order}: {quadax.STATUS[int(info.status)]}"
+            assert info.status == quadax.STATUS.normal, (
+                f"{prob['name']} at order {order}: {quadax.STATUS[info.status]}"
             )
             ninter.append(int(info.info["ninter"]))
         assert all(hi <= lo for lo, hi in zip(ninter, ninter[1:])), (
@@ -290,9 +293,9 @@ class TestExtrapolation:
             extrapolate=True,
         )
         np.testing.assert_allclose(float(y), finite_part, rtol=1e-6)
-        assert int(info.status) & 2**quadax.adaptive.DIVERGENT
-        # the docstrings tell users to look the code up in STATUS, so it has to be there
-        assert quadax.STATUS[int(info.status)].strip()
+        assert info.status == quadax.STATUS.divergent
+        # the docstrings tell users to print the flag, so it has to carry a message
+        assert quadax.STATUS[info.status].strip()
 
     def test_no_asymptotic_structure_falls_back(self):
         """``sin(1/x)`` has no trend to extrapolate, so the table must not win.
@@ -322,7 +325,7 @@ class TestExtrapolation:
         )
         # Either it is right, or it says it is not; what it must not do is both be
         # wrong and report success.
-        if int(info.status) == 0:
+        if info.status == quadax.STATUS.normal:
             np.testing.assert_allclose(float(y), ref, rtol=1e-8, atol=1e-10)
 
     @pytest.mark.parametrize("i", ALL, ids=problem_id)
@@ -538,7 +541,9 @@ def test_converged_iteration_exits_clean(max_ninter):
     )
     err = float(info.err)
     if 0 <= err <= max(tol, tol * abs(float(y))):
-        assert int(info.status) == 0, f"reported failure at err={err:.3e} <= {tol:.0e}"
+        assert info.status == quadax.STATUS.normal, (
+            f"reported failure at err={err:.3e} <= {tol:.0e}"
+        )
 
 
 # A tall narrow peak: 1e8 at its top, integral 3.1e4, so the error estimates the loop
@@ -560,7 +565,7 @@ def test_no_spurious_roundoff_on_unresolved_integrand():
     reporting ROUNDOFF with an error five orders of magnitude worse than achievable.
     """
     y, info = quadgk(_PEAK, jnp.array([0.0, 1.0]), epsabs=1e-12, epsrel=1e-12)
-    assert int(info.status) == 0, quadax.STATUS[int(info.status)]
+    assert info.status == quadax.STATUS.normal, quadax.STATUS[info.status]
     np.testing.assert_allclose(float(y), _PEAK_VAL, rtol=1e-13, atol=0)
 
 
@@ -575,7 +580,7 @@ def test_tolerance_below_roundoff_floor_reports_roundoff():
     true, but not the reason; quadax tests it every iteration instead.
     """
     _, info = quadgk(_PEAK, jnp.array([0.0, 1.0]), epsabs=1e-14, epsrel=1e-14)
-    assert int(info.status) & 2**2, quadax.STATUS[int(info.status)]
+    assert info.status == quadax.STATUS.roundoff, quadax.STATUS[info.status]
     # and the error it stopped at really is the accumulated floor
     np.testing.assert_allclose(
         float(info.err), 50 * np.finfo(np.float64).eps * _PEAK_VAL, rtol=1e-3
@@ -613,7 +618,7 @@ class TestIntervalScaling:
             epsabs=jnp.asarray(0.0),
             epsrel=jnp.asarray(1e-10),
         )
-        assert int(info.status) == 0, quadax.STATUS[int(info.status)]
+        assert info.status == quadax.STATUS.normal, quadax.STATUS[info.status]
         np.testing.assert_allclose(float(y) / s, 0.8862073482595214, rtol=1e-10)
 
     @pytest.mark.parametrize("scale", [1e-8, 1.0, 1e8])
@@ -935,7 +940,7 @@ def _assert_same_run(got, want):
     np.testing.assert_allclose(
         np.asarray(info_b.err), np.asarray(info.err), rtol=ULP_RTOL, atol=ULP_ATOL
     )
-    assert int(info_b.status) == int(info.status)
+    assert info_b.status == info.status
     assert int(info_b.info["ninter"]) == int(info.info["ninter"])
 
 
@@ -1016,3 +1021,38 @@ def test_bad_batch_size_rejected(method, batch_size):
     """A batch size that is not a positive integer is a mistake, not a default."""
     with pytest.raises(ValueError, match="batch_size"):
         method(exp_neg, jnp.array([0.0, 1.0]), batch_size=batch_size)
+
+
+@pytest.mark.parametrize(
+    "method, budget",
+    [
+        (quadgk, {"max_ninter": 8}),
+        (quadcc, {"max_ninter": 8}),
+        (quadts, {"max_ninter": 8}),
+        (romberg, {"divmax": 6}),
+        (rombergts, {"divmax": 6}),
+    ],
+    ids=["gk", "cc", "ts", "romberg", "rombergts"],
+)
+def test_throw_raises_with_the_status_it_would_have_reported(method, budget):
+    """``throw`` turns the reported status into an exception carrying its own message.
+
+    A zero tolerance is a request no run can meet, so every routine spends its budget
+    and flags; which flag it settles on differs between them, and the message raised has
+    to be that flag's rather than a generic one. The default leaves the status on
+    ``info`` and raises nothing, so switching ``throw`` on is the only difference.
+    """
+    fun = lambda t: t * jnp.log(1 + t)  # noqa: E731
+    interval = jnp.array([0.0, 1.0])
+    unreachable = dict(epsabs=0.0, epsrel=0.0, **budget)
+
+    _, info = method(fun, interval, **unreachable)
+    assert info.status != quadax.STATUS.normal
+    expected = re.escape(quadax.STATUS[info.status][:40])
+    with pytest.raises(eqx.EquinoxRuntimeError, match=expected):
+        method(fun, interval, throw=True, **unreachable)
+
+    # A run that reaches the tolerance is unaffected by asking.
+    y, info = method(fun, interval, epsabs=1e-8, epsrel=1e-8, throw=True)
+    assert info.status == quadax.STATUS.normal
+    np.testing.assert_allclose(float(y), 0.25, rtol=1e-8)

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -16,6 +16,7 @@ from quadax import (
     DirectAdjoint,
     GaussKronrodRule,
     LeibnizAdjoint,
+    TanhSinhRule,
     quadcc,
     quadgk,
     quadts,
@@ -686,6 +687,188 @@ class TestUnifiedLeibnizAdjoint:
         )
 
 
+class TestAdjointOptions:
+    """LeibnizAdjoint's solve can be configured separately from the primal's."""
+
+    # Vector valued, so that the integrand's own shape and the number of parameters are
+    # different numbers and a norm can tell which of the two it is being handed.
+    fun = staticmethod(
+        lambda t, c: jnp.array([jnp.sum(jnp.sin(c * t)), jnp.sum(jnp.cos(c * t))])
+    )
+    interval = jnp.array([0.0, 1.0])
+    args = jnp.linspace(0.5, 2.0, 3)
+
+    # An integrand far easier to integrate than to differentiate: the peak the tangent
+    # sees has width sqrt(s), while the integral itself is smooth. The derivative solve
+    # is then what the options are visibly doing something to.
+    peaked = staticmethod(lambda t, s: jnp.exp(-((t - 0.5) ** 2) / s[0]))
+    peak_args = jnp.array([1e-3])
+
+    def _spy(self, seen):
+        """A norm that records the shape of every vector it measures."""
+
+        def norm(x):
+            seen.append(jnp.shape(x))
+            return jnp.linalg.norm(jnp.asarray(x).flatten(), ord=jnp.inf)
+
+        return norm
+
+    def _dpeak(self, **options):
+        f = lambda s: quadgk(  # noqa: E731
+            self.peaked,
+            self.interval,
+            (s,),
+            epsabs=1e-6,
+            epsrel=1e-6,
+            adjoint=LeibnizAdjoint(options=options),
+        )[0]
+        return float(jax.grad(f)(self.peak_args)[0])
+
+    def test_options_leave_the_integral_alone(self):
+        """Only the derivative solve is reconfigured, never the primal."""
+        y0, info0 = quadgk(
+            self.peaked, self.interval, (self.peak_args,), epsabs=1e-6, epsrel=1e-6
+        )
+        y1, info1 = quadgk(
+            self.peaked,
+            self.interval,
+            (self.peak_args,),
+            epsabs=1e-6,
+            epsrel=1e-6,
+            adjoint=LeibnizAdjoint(options={"epsabs": 1e-1, "max_ninter": 2}),
+        )
+        assert float(y0) == float(y1)
+        assert float(info0.err) == float(info1.err)
+        assert int(info0.neval) == int(info1.neval)
+
+    def test_budget_reaches_the_derivative(self):
+        """A derivative solved on a starved budget is measurably worse."""
+        exact = lambda s: float(  # noqa: E731
+            quadgk(self.peaked, self.interval, (s,), epsabs=1e-13, epsrel=1e-13)[0]
+        )
+        h = 1e-9
+        ref = (exact(self.peak_args + h) - exact(self.peak_args - h)) / (2 * h)
+        assert abs(self._dpeak(max_ninter=2) - ref) > 100 * abs(self._dpeak() - ref)
+
+    @pytest.mark.parametrize("quad", [quadgk, romberg])
+    def test_unknown_option_raises(self, quad):
+        """A misspelled option is caught by the solve rather than silently ignored."""
+        f = lambda c: quad(  # noqa: E731
+            self.fun, self.interval, (c,), adjoint=LeibnizAdjoint(options={"nope": 1})
+        )[0].sum()
+        with pytest.raises(TypeError, match="nope"):
+            jax.grad(f)(self.args)
+
+    def test_traced_tolerance_does_not_retrace(self):
+        """An override may be a traced array, and then costs no recompilation."""
+        traces = []
+        f = lambda s, tol: (  # noqa: E731
+            traces.append(None),
+            quadgk(
+                self.peaked,
+                self.interval,
+                (s,),
+                adjoint=LeibnizAdjoint(options={"epsabs": tol}),
+            )[0],
+        )[1]
+        g = jax.jit(jax.grad(f))
+        values = [float(g(self.peak_args, jnp.asarray(t))[0]) for t in (1e-8, 1e-10)]
+        assert len(traces) == 1
+        np.testing.assert_allclose(values[0], values[1], rtol=1e-6)
+
+    def test_norm_is_scoped_to_one_direction(self):
+        """Each direction measures its own vector, and only the norm it was given.
+
+        The two vectors have different lengths here, the integrand having two components
+        and there being three parameters, so which norm saw which is not in doubt.
+        """
+        primal, fwd, rev = [], [], []
+        f = lambda c: quadgk(  # noqa: E731
+            self.fun,
+            self.interval,
+            (c,),
+            norm=self._spy(primal),
+            adjoint=LeibnizAdjoint(
+                options_fwd={"norm": self._spy(fwd)},
+                options_rev={"norm": self._spy(rev)},
+            ),
+        )[0].sum()
+        jax.grad(f)(self.args)
+        # Reverse mode integrates the cotangent of the three parameters, and forward
+        # mode did not run at all.
+        assert set(rev) == {(3,)} and fwd == []
+        for seen in (primal, fwd, rev):
+            seen.clear()
+        jax.jvp(f, (self.args,), (jnp.ones_like(self.args),))
+        # Forward mode integrates the tangent of the integrand, a vector of the
+        # integrand's own shape, which a norm meant for the cotangent must not be
+        # handed, all the more so because the two can be the same length elsewhere.
+        assert set(fwd) == {(2,)} and rev == []
+        assert set(primal) == {(2,)}
+
+    def test_weighted_norm_against_the_documented_layout(self):
+        """The workflow the reverse layout is for: weight a parameter, and solve.
+
+        The cotangent vector holds the differentiated arguments in order, so with only
+        ``args[0]`` differentiated it is the three parameters and nothing else, and a
+        weight per parameter can be written down directly.
+        """
+        f = lambda c, adj: quadgk(  # noqa: E731
+            self.fun, self.interval, (c,), adjoint=adj
+        )[0].sum()
+        weights = jnp.array([1.0, 10.0, 100.0])
+        norm = lambda x: jnp.linalg.norm(x * weights, ord=jnp.inf)  # noqa: E731
+        np.testing.assert_allclose(
+            np.asarray(
+                jax.grad(f)(self.args, LeibnizAdjoint(options_rev={"norm": norm}))
+            ),
+            np.asarray(jax.grad(f)(self.args, LeibnizAdjoint())),
+            rtol=1e-8,
+        )
+
+    @pytest.mark.parametrize("rule", [GaussKronrodRule(61), TanhSinhRule(61)])
+    def test_derivative_takes_its_own_rule(self, rule):
+        """The derivative may be taken with a different local rule than the integral."""
+        f = lambda c, adj: quadgk(  # noqa: E731
+            self.fun, self.interval, (c,), adjoint=adj
+        )[0].sum()
+        np.testing.assert_allclose(
+            np.asarray(
+                jax.grad(f)(self.args, LeibnizAdjoint(options_rev={"rule": rule}))
+            ),
+            np.asarray(jax.grad(f)(self.args, LeibnizAdjoint())),
+            rtol=1e-8,
+            atol=1e-12,
+        )
+
+    @pytest.mark.parametrize("quad", romberg_methods)
+    def test_romberg_options(self, quad):
+        """Romberg takes its own level schedule and norm."""
+        seen = []
+        adjoint = LeibnizAdjoint(
+            options={"divmax": 15, "divmin": 6, "batch_size": 32, "epsabs": 1e-11},
+            options_rev={"norm": self._spy(seen)},
+        )
+        f = lambda c: quad(self.fun, self.interval, (c,), adjoint=adjoint)[0].sum()
+        ref = jax.grad(lambda c: quad(self.fun, self.interval, (c,))[0].sum())(
+            self.args
+        )
+        np.testing.assert_allclose(np.asarray(jax.grad(f)(self.args)), ref, rtol=1e-8)
+        assert set(seen) == {(3,)}
+
+    def test_starved_schedule_is_rejected(self):
+        """A schedule the adjoint's options make inconsistent is caught too."""
+        with pytest.raises(ValueError, match="divmin"):
+            jax.grad(
+                lambda c: romberg(
+                    self.fun,
+                    self.interval,
+                    (c,),
+                    adjoint=LeibnizAdjoint(options={"divmax": 3, "divmin": 9}),
+                )[0].sum()
+            )(self.args)
+
+
 @pytest.mark.parametrize("quad", all_methods)
 @pytest.mark.parametrize("adjoint", [DirectAdjoint(), LeibnizAdjoint()])
 def test_integer_limits(quad, adjoint):
@@ -1016,12 +1199,12 @@ class TestExtrapolatedAdjoints:
         )
         rule = GaussKronrodRule(21)
         y, state = _adaptive_solve(
-            rule,
             vfunc,
             interval_t,
-            jnp.asarray(1e-12),
-            jnp.asarray(1e-12),
             {},
+            rule=rule,
+            epsabs=jnp.asarray(1e-12),
+            epsrel=jnp.asarray(1e-12),
             max_ninter=100,
             extrapolate=True,
         )

--- a/tests/test_fixed_order.py
+++ b/tests/test_fixed_order.py
@@ -38,7 +38,12 @@ import pytest
 import scipy.special
 from jax import config
 
-from quadax import ClenshawCurtisRule, GaussKronrodRule, TanhSinhRule
+from quadax import (
+    AbstractQuadratureRule,
+    ClenshawCurtisRule,
+    GaussKronrodRule,
+    TanhSinhRule,
+)
 
 from .problems import SLOP, ULP_ATOL, ULP_RTOL, exp_neg, real_dtypes
 
@@ -750,3 +755,41 @@ def test_bad_batch_size_rejected(rule, batch_size):
     """A batch size that is not a positive integer is a mistake, not a default."""
     with pytest.raises(ValueError, match="batch_size"):
         rule(batch_size=batch_size)
+
+
+@pytest.mark.usefixtures("quiet_tanhsinh")
+@pytest.mark.parametrize("rule", RULES, ids=RULE_IDS)
+class TestWithNorm:
+    """A rule can be rebuilt to measure vector valued error with a different norm.
+
+    This is how an adjoint running an error controlled solve of its own measures a
+    vector that is not the integrand's output, see ``LeibnizAdjoint``.
+    """
+
+    x = jnp.array([3.0, -4.0])
+
+    def test_order_or_callable(self, rule):
+        """An int asks for that p-norm, a callable is used as given, as in __init__."""
+        assert float(rule()._with_norm(2).norm(self.x)) == 5.0
+        assert float(rule()._with_norm(1).norm(self.x)) == 7.0
+        assert float(rule()._with_norm(lambda x: jnp.sum(x**2)).norm(self.x)) == 25.0
+
+    def test_rebuilds_rather_than_mutates(self, rule):
+        """The original keeps its own norm, and the quadrature itself is unchanged."""
+        original = rule()
+        assert float(original._with_norm(1).norm(self.x)) == 7.0
+        assert float(original.norm(self.x)) == 4.0
+        np.testing.assert_array_equal(
+            np.asarray(original._with_norm(1)._xh), np.asarray(original._xh)
+        )
+
+
+def test_with_norm_needs_a_norm_to_replace():
+    """A rule that does not measure error from a norm says so rather than guessing."""
+
+    class NoNorm(AbstractQuadratureRule):
+        def integrate(self, fun, a, b, args):
+            raise NotImplementedError
+
+    with pytest.raises(NotImplementedError, match="not built from a norm"):
+        NoNorm()._with_norm(2)

--- a/tests/test_romberg.py
+++ b/tests/test_romberg.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 from jax import config
 
-from quadax import romberg, rombergts
+from quadax import STATUS, romberg, rombergts
 
 from .problems import (
     NO_BREAKPOINTS,
@@ -70,7 +70,7 @@ class TestRomberg:
         y, info = solve_once(method, i, tol, interval_as_array=True)
         # Convergence is required only of the problems the method is for; the rest are
         # swept to check they fail honestly, which `test_error_is_honest` covers.
-        if i not in EXPECTED_TO_CONVERGE[method] and int(info.status) != 0:
+        if i not in EXPECTED_TO_CONVERGE[method] and info.status != STATUS.normal:
             pytest.skip("convergence is not required of this case")
         assert_converged(y, info, prob, tol)
 
@@ -108,7 +108,7 @@ class TestRichardsonFlag:
         # error rather than dividing by it.
         scale = max(np.max(np.abs(exact)), 1.0)
         err = float(np.max(np.abs(np.asarray(y) - exact)) / scale)
-        return y, err, int(info.status), int(info.neval)
+        return y, err, info.status, int(info.neval)
 
     def test_richardson_is_what_makes_romberg_work(self):
         """Without it the trapezoidal rule cannot keep up on a smooth integrand.
@@ -418,7 +418,7 @@ class TestDivmin:
             divmax=12,
             divmin=divmin,
         )
-        assert int(info.status) == 0
+        assert info.status == STATUS.normal
         np.testing.assert_allclose(
             np.asarray(y), np.asarray(prob["val"]), rtol=self.TOL, atol=self.TOL
         )
@@ -494,7 +494,7 @@ class TestDivmin:
             divmax=12,
             divmin=5,
         )
-        assert int(info.status) == 0
+        assert info.status == STATUS.normal
         np.testing.assert_allclose(
             np.asarray(y), np.asarray(prob["val"]), rtol=1e-9, atol=1e-9
         )
@@ -551,3 +551,28 @@ def test_divmin_above_divmax_rejected(method):
     """Starting below the floor the run is allowed to reach is a contradiction."""
     with pytest.raises(ValueError, match="divmin"):
         method(PROBLEMS[0]["fun"], jnp.array([0.0, 1.0]), divmin=6, divmax=4)
+
+
+@pytest.mark.parametrize(
+    "method, fun, tol, divmax, expect",
+    [
+        # Nowhere near resolving an endpoint singularity in six uniform halvings.
+        (romberg, lambda t: t**-0.5, 1e-8, 6, "max_divisions"),
+        # Below what the arithmetic can deliver, however many levels remain.
+        (romberg, jnp.exp, 1e-17, 20, "roundoff"),
+        # Below what the map's own tail leaves outside the abscissae.
+        (rombergts, lambda t: t**-0.5, 1e-16, 20, "truncation"),
+    ],
+    ids=["out-of-levels", "below-roundoff-floor", "below-truncation-floor"],
+)
+def test_romberg_names_its_own_exit_condition(method, fun, tol, divmax, expect):
+    """The three ways a Romberg schedule can stop short are reported apart.
+
+    They call for different things - more levels, a looser tolerance, a different map -
+    and collapsing them into one "did not converge" tells the reader none of that. The
+    two floors are what distinguish them from running out of budget: neither can be
+    crossed by refining, so more levels would only spend evaluations reaching the same
+    answer.
+    """
+    _, info = method(fun, jnp.array([0.0, 1.0]), epsabs=tol, epsrel=tol, divmax=divmax)
+    assert info.status == getattr(STATUS, expect), STATUS[info.status]


### PR DESCRIPTION
- Reworked how a routine reports why it stopped.
  - `QuadratureInfo.status` is now a `quadax.STATUS` naming the termination condition,
    where it was previously an integer bitmask. `STATUS.normal` means the requested
    tolerances were reached; every other member prints as the message explaining the
    difficulty. This is a breaking change: `int(info.status)` and the old
    `quadax.STATUS` lookup table are both gone, replaced by comparing against members,
    eg `info.status == quadax.STATUS.divergent`.
  - All six quadrature routines take a new `throw` option, default False. With
    `throw=True` a run that stops for any reason other than reaching the requested
    tolerance raises, with the message its status carries; the default reports the
    status on `info` and leaves it to the caller.
  - A run meeting more than one condition now reports the most severe rather than a
    bitmask of all of them, ordered by what a reader should do about it: spend more
    budget, distrust the error estimate, distrust the answer. Where the conditions
    combined before, the reported one is the actionable one.
- The adjoint solve performed by ``LeibnizAdjoint`` can now be configured separately
  from the integral's, via ``LeibnizAdjoint(options={...}, options_fwd={...},`` 
  ``options_rev={...})``. ``options_fwd`` and ``options_rev`` configure one direction
  alone, taking precedence over ``options``. This matters most for ``norm``, because 
  the two directions measure different vectors: forward mode integrates the tangent 
  of the integrand, of the integrand's own shape, while reverse mode integrates the 
  cotangent of the arguments being differentiated, whose layout is documented on 
  ``LeibnizAdjoint``.