### PR TITLE
Support JAX 0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "equinox >= 0.11.0, < 0.14",
-  "jax >= 0.5.0, < 0.11",
+  "jax >= 0.5.0, < 0.12",
   "numpy >= 1.20.0, < 2.5",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Summary\n\n- Extend the declared JAX range from below 0.11 to below 0.12.\n- Keep the existing JAX 0.5 lower bound unchanged.\n\nValidation\n\n- Full test suite with JAX 0.11.1: 3304 passed, 180 skipped, 81 xfailed, 1 xpassed.\n- The repository JAX-version matrix has also passed JAX 0.11.0 and 0.11.1.\n- All five integration entry points used downstream by ELISA execute successfully with JAX 0.11.1.\n\nA 0.2.x release containing this metadata change would allow downstream packages to declare JAX 0.11 support without dependency overrides.